### PR TITLE
feat(embedded): introduce EngineCommandExecutor for pluggable command dispatch

### DIFF
--- a/docs/reference-cib-seven-embedded.md
+++ b/docs/reference-cib-seven-embedded.md
@@ -51,3 +51,33 @@ the real type, you want to access if reading the field. For this purpose, `TaskI
 | tenantId             | String         | Tenant Id                                                  | my_tenant                     |
 | topicName            | String         | Topic name (from BPMN) for external task                   | topic_approve                 |
 | creationDate         | OffsetDateTime | Time stamp of task creation formatted as ISO-8601 in UTC   | 2025-05-01T10:00:00.000Z      |
+
+## Engine Command Executor
+
+`EngineCommandExecutor` is an embedded-adapter-specific class that controls how the four core API calls
+(`correlateMessage`, `sendSignal`, `startProcess`, `deploy`) are dispatched to the embedded CIB Seven engine.
+
+By default, all engine calls are submitted asynchronously to `ForkJoinPool.commonPool()`. This means they run on a
+**different thread** from the caller and do **not** participate in the caller's `@Transactional` context — a rollback
+on the calling thread will **not** roll back the engine operation.
+
+### Customizing execution
+
+Provide a Spring bean of type `EngineCommandExecutor` to override the default. The
+auto-configured default is annotated with `@ConditionalOnMissingBean`, so your bean takes precedence automatically.
+
+**Same-thread (synchronous) execution** — engine calls run on the calling thread and honour `@Transactional`:
+
+```kotlin
+@Bean
+fun engineCommandExecutor(): EngineCommandExecutor =
+  EngineCommandExecutor(Executor { it.run() })
+```
+
+**Virtual-thread execution** — lightweight concurrency without pinning platform threads:
+
+```kotlin
+@Bean
+fun engineCommandExecutor(): EngineCommandExecutor =
+  EngineCommandExecutor(Executors.newVirtualThreadPerTaskExecutor())
+```

--- a/engine-adapter/cib-seven-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/correlation/CorrelationApiImpl.kt
+++ b/engine-adapter/cib-seven-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/correlation/CorrelationApiImpl.kt
@@ -5,6 +5,7 @@ import dev.bpmcrafters.processengineapi.Empty
 import dev.bpmcrafters.processengineapi.MetaInfo
 import dev.bpmcrafters.processengineapi.MetaInfoAware
 import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.correlation.CorrelationApiImpl.Restrictions.USE_GLOBAL_CORRELATION_KEY
+import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.shared.EngineCommandExecutor
 import dev.bpmcrafters.processengineapi.correlation.CorrelateMessageCmd
 import dev.bpmcrafters.processengineapi.correlation.CorrelationApi
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -18,6 +19,7 @@ private val logger = KotlinLogging.logger {}
  */
 class CorrelationApiImpl(
   private val runtimeService: RuntimeService,
+  private val commandExecutor: EngineCommandExecutor
 ) : CorrelationApi {
 
   object Restrictions {
@@ -25,7 +27,7 @@ class CorrelationApiImpl(
   }
 
   override fun correlateMessage(cmd: CorrelateMessageCmd): CompletableFuture<Empty> {
-    return CompletableFuture.supplyAsync {
+    return commandExecutor.execute {
       val correlation = cmd.correlation.get()
       val globalCorrelation = cmd.restrictions.containsKey(USE_GLOBAL_CORRELATION_KEY)
         && cmd.restrictions.getValue(USE_GLOBAL_CORRELATION_KEY).toBoolean()

--- a/engine-adapter/cib-seven-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/correlation/SignalApiImpl.kt
+++ b/engine-adapter/cib-seven-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/correlation/SignalApiImpl.kt
@@ -4,6 +4,7 @@ import dev.bpmcrafters.processengineapi.CommonRestrictions
 import dev.bpmcrafters.processengineapi.Empty
 import dev.bpmcrafters.processengineapi.MetaInfo
 import dev.bpmcrafters.processengineapi.MetaInfoAware
+import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.shared.EngineCommandExecutor
 import dev.bpmcrafters.processengineapi.correlation.SendSignalCmd
 import dev.bpmcrafters.processengineapi.correlation.SignalApi
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -14,15 +15,16 @@ import java.util.concurrent.CompletableFuture
 private val logger = KotlinLogging.logger {}
 
 /**
- * Implementation of Signal API using local runtime service.
+ * Implementation of Signal API using a local runtime service.
  */
 class SignalApiImpl(
-  private val runtimeService: RuntimeService
+  private val runtimeService: RuntimeService,
+  private val commandExecutor: EngineCommandExecutor
 ) : SignalApi {
 
   override fun sendSignal(cmd: SendSignalCmd): CompletableFuture<Empty> {
     logger.debug { "PROCESS-ENGINE-CIB7-EMBEDDED-002: sending signal ${cmd.signalName}." }
-    return CompletableFuture.supplyAsync {
+    return commandExecutor.execute {
       runtimeService
         .createSignalEvent(cmd.signalName)
         .applyRestrictions(ensureSupported(cmd.restrictions))

--- a/engine-adapter/cib-seven-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/deploy/DeploymentApiImpl.kt
+++ b/engine-adapter/cib-seven-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/deploy/DeploymentApiImpl.kt
@@ -2,6 +2,7 @@ package dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.deploy
 
 import dev.bpmcrafters.processengineapi.MetaInfo
 import dev.bpmcrafters.processengineapi.MetaInfoAware
+import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.shared.EngineCommandExecutor
 import dev.bpmcrafters.processengineapi.deploy.DeployBundleCommand
 import dev.bpmcrafters.processengineapi.deploy.DeploymentApi
 import dev.bpmcrafters.processengineapi.deploy.DeploymentInformation
@@ -16,13 +17,14 @@ private val logger = KotlinLogging.logger {}
  * Implementation for deployment API using repository service.
  */
 class DeploymentApiImpl(
-  private val repositoryService: RepositoryService
+  private val repositoryService: RepositoryService,
+  private val commandExecutor: EngineCommandExecutor
 ) : DeploymentApi {
 
   override fun deploy(cmd: DeployBundleCommand): CompletableFuture<DeploymentInformation> {
     require(cmd.resources.isNotEmpty()) { "Resources must not be empty, at least one resource must be provided." }
     logger.debug { "PROCESS-ENGINE-CIB7-EMBEDDED-003: executing a bundle deployment with ${cmd.resources.size} resources." }
-    return CompletableFuture.supplyAsync {
+    return commandExecutor.execute {
       repositoryService
         .createDeployment()
         .apply {

--- a/engine-adapter/cib-seven-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/process/StartProcessApiImpl.kt
+++ b/engine-adapter/cib-seven-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/process/StartProcessApiImpl.kt
@@ -4,7 +4,13 @@ import dev.bpmcrafters.processengineapi.CommonRestrictions
 import dev.bpmcrafters.processengineapi.MetaInfo
 import dev.bpmcrafters.processengineapi.MetaInfoAware
 import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.correlation.applyTenantRestrictions
-import dev.bpmcrafters.processengineapi.process.*
+import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.shared.EngineCommandExecutor
+import dev.bpmcrafters.processengineapi.process.ProcessInformation
+import dev.bpmcrafters.processengineapi.process.StartProcessApi
+import dev.bpmcrafters.processengineapi.process.StartProcessByDefinitionAtElementCmd
+import dev.bpmcrafters.processengineapi.process.StartProcessByDefinitionCmd
+import dev.bpmcrafters.processengineapi.process.StartProcessByMessageCmd
+import dev.bpmcrafters.processengineapi.process.StartProcessCommand
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.cibseven.bpm.engine.RepositoryService
 import org.cibseven.bpm.engine.RuntimeService
@@ -19,31 +25,32 @@ private val logger = KotlinLogging.logger {}
 class StartProcessApiImpl(
   private val runtimeService: RuntimeService,
   private val repositoryService: RepositoryService,
+  private val commandExecutor: EngineCommandExecutor
 ) : StartProcessApi {
 
   override fun startProcess(cmd: StartProcessCommand): CompletableFuture<ProcessInformation> {
     return when (cmd) {
       is StartProcessByDefinitionCmd ->
-        CompletableFuture.supplyAsync {
+        commandExecutor.execute {
           logger.debug { "PROCESS-ENGINE-CIB7-EMBEDDED-004: starting a new process instance by definition ${cmd.definitionKey}." }
           ensureSupported(cmd.restrictions)
           val payload = cmd.payloadSupplier.get()
           val businessKey = payload[CommonRestrictions.BUSINESS_KEY]?.toString()
           val tenantId = cmd.restrictions[CommonRestrictions.TENANT_ID]
           if (!tenantId.isNullOrBlank()) {
-            repositoryService
+            val processDefinition = repositoryService
               .createProcessDefinitionQuery()
               .processDefinitionKey(cmd.definitionKey)
               .tenantIdIn(tenantId)
               .active()
               .latestVersion()
-              .singleResult()?.let { processDefinition ->
-                runtimeService.startProcessInstanceById(
-                  processDefinition.id,
-                  businessKey,
-                  payload,
-                ).toProcessInformation()
-              }
+              .singleResult()
+            requireNotNull(processDefinition) { "No process definition found for key ${cmd.definitionKey} and tenant $tenantId" }
+            runtimeService.startProcessInstanceById(
+              processDefinition.id,
+              businessKey,
+              payload,
+            ).toProcessInformation()
           } else {
             runtimeService.startProcessInstanceByKey(
               cmd.definitionKey,
@@ -54,7 +61,7 @@ class StartProcessApiImpl(
         }
 
       is StartProcessByMessageCmd ->
-        CompletableFuture.supplyAsync {
+        commandExecutor.execute {
           logger.debug { "PROCESS-ENGINE-CIB7-EMBEDDED-005: starting a new process instance by message ${cmd.messageName}." }
           val payload = cmd.payloadSupplier.get()
           var correlationBuilder = runtimeService.createMessageCorrelation(cmd.messageName)
@@ -70,7 +77,7 @@ class StartProcessApiImpl(
         }
 
       is StartProcessByDefinitionAtElementCmd ->
-        CompletableFuture.supplyAsync {
+        commandExecutor.execute {
           logger.debug { "PROCESS-ENGINE-CIB7-EMBEDDED-006: starting a new process instance by definition ${cmd.definitionKey} at element ${cmd.elementId}" }
           val startProcessCommand = StartProcessByDefinitionCmd(
             definitionKey = cmd.definitionKey,

--- a/engine-adapter/cib-seven-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/shared/EngineCommandExecutor.kt
+++ b/engine-adapter/cib-seven-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/shared/EngineCommandExecutor.kt
@@ -1,0 +1,34 @@
+package dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.shared
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+import java.util.concurrent.ForkJoinPool
+
+/**
+ * Controls how commands to the engine are dispatched.
+ * By default, commands run asynchronously on [ForkJoinPool.commonPool]
+ * mirroring the behavior of a remote engine
+ *
+ * This design choice was made on purpose to keep adapters portable across engine implementations
+ * (embedded ↔ remote, Camunda 7 ↔ Zeebe).
+ *
+ * However, it causes that engine calls do not join the caller's transaction.
+ * A rollback triggered elsewhere will not undo what the engine already executed,
+ * risking data inconsistencies between your service and the engine.
+ *
+ * Override this bean with any [Executor] to change the dispatch strategy.
+ * The most common use case for this is transactional coupling via a same-thread executor:
+ *
+ * ```
+ * @Bean fun engineCommandExecutor() = EngineCommandExecutor { it.run() }
+ * ```
+ */
+class EngineCommandExecutor(
+  private val executor: Executor = ForkJoinPool.commonPool()
+) {
+  fun <T> execute(
+    supplier: () -> T
+  ): CompletableFuture<T> {
+    return CompletableFuture.supplyAsync({ supplier() }, executor)
+  }
+}

--- a/engine-adapter/cib-seven-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/testing/AbstractCib7EmbeddedStage.kt
+++ b/engine-adapter/cib-seven-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/testing/AbstractCib7EmbeddedStage.kt
@@ -12,6 +12,7 @@ import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.correlation.Si
 import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.deploy.DeploymentApiImpl
 import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.process.CachingProcessDefinitionMetaDataResolver
 import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.process.StartProcessApiImpl
+import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.shared.EngineCommandExecutor
 import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.task.completion.Cib7ServiceTaskCompletionApiImpl
 import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.task.completion.Cib7UserTaskCompletionApiImpl
 import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.task.completion.LinearMemoryFailureRetrySupplier
@@ -45,6 +46,7 @@ import org.cibseven.bpm.engine.runtime.ProcessInstance
 import org.cibseven.bpm.engine.test.assertions.bpmn.BpmnAwareTests
 import org.cibseven.bpm.engine.variable.VariableMap
 import java.util.*
+import java.util.concurrent.Executor
 import java.util.concurrent.Executors
 
 /**
@@ -130,12 +132,17 @@ abstract class AbstractCib7EmbeddedStage<SUBTYPE : AbstractCib7EmbeddedStage<SUB
     this.workerId = self().javaClass.simpleName
 
     val subscriptionRepository = InMemSubscriptionRepository()
+    val commandExecutor = EngineCommandExecutor(Executor { it.run() })
 
     startProcessApi = StartProcessApiImpl(
       runtimeService = processEngineServices.runtimeService,
       repositoryService = processEngineServices.repositoryService,
+      commandExecutor = commandExecutor
     )
-    deploymentApi = DeploymentApiImpl(processEngineServices.repositoryService)
+    deploymentApi = DeploymentApiImpl(
+      repositoryService = processEngineServices.repositoryService,
+      commandExecutor = commandExecutor
+    )
     userTaskCompletionApi = Cib7UserTaskCompletionApiImpl(processEngineServices.taskService, subscriptionRepository)
     serviceTaskCompletionApi = Cib7ServiceTaskCompletionApiImpl(
       workerId, processEngineServices.externalTaskService, subscriptionRepository, LinearMemoryFailureRetrySupplier(3, 3L)
@@ -162,8 +169,14 @@ abstract class AbstractCib7EmbeddedStage<SUBTYPE : AbstractCib7EmbeddedStage<SUB
       taskSubscriptionApi, restrictions, null, null
     )
 
-    signalApi = SignalApiImpl(processEngineServices.runtimeService)
-    correlationApi = CorrelationApiImpl(processEngineServices.runtimeService)
+    signalApi = SignalApiImpl(
+      runtimeService = processEngineServices.runtimeService,
+      commandExecutor = commandExecutor
+    )
+    correlationApi = CorrelationApiImpl(
+      runtimeService = processEngineServices.runtimeService,
+      commandExecutor = commandExecutor
+    )
 
     initialize()
 

--- a/engine-adapter/cib-seven-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/correlation/CorrelationApiImplTest.kt
+++ b/engine-adapter/cib-seven-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/correlation/CorrelationApiImplTest.kt
@@ -1,6 +1,7 @@
 package dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.correlation
 
 import dev.bpmcrafters.processengineapi.CommonRestrictions
+import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.shared.EngineCommandExecutor
 import dev.bpmcrafters.processengineapi.correlation.CorrelateMessageCmd
 import dev.bpmcrafters.processengineapi.correlation.Correlation
 import org.cibseven.bpm.engine.RuntimeService
@@ -8,20 +9,17 @@ import org.cibseven.bpm.engine.runtime.MessageCorrelationBuilder
 import org.cibseven.community.mockito.ProcessExpressions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.InjectMocks
 import org.mockito.Mockito.mock
-import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 
-@ExtendWith(MockitoExtension::class)
 class CorrelationApiImplTest {
 
   private val runtimeService: RuntimeService = mock()
-
-  @InjectMocks
-  private lateinit var correlationApi: CorrelationApiImpl
+  private val correlationApi = CorrelationApiImpl(
+    runtimeService = runtimeService,
+    commandExecutor = EngineCommandExecutor { it.run() }
+  )
 
   private lateinit var correlation: MessageCorrelationBuilder
 
@@ -64,6 +62,6 @@ class CorrelationApiImplTest {
     verify(correlation).setVariables(mapOf("some" to 1L))
     verify(correlation).processInstanceVariableEquals("myCorrelation", "varValue")
     verifyNoMoreInteractions(correlation)
-
   }
+
 }

--- a/engine-adapter/cib-seven-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/correlation/SignalApiImplTest.kt
+++ b/engine-adapter/cib-seven-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/correlation/SignalApiImplTest.kt
@@ -1,0 +1,54 @@
+package dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.correlation
+
+import dev.bpmcrafters.processengineapi.Empty
+import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.shared.EngineCommandExecutor
+import dev.bpmcrafters.processengineapi.correlation.SendSignalCmd
+import org.assertj.core.api.Assertions.assertThat
+import org.cibseven.bpm.engine.RuntimeService
+import org.cibseven.bpm.engine.runtime.SignalEventReceivedBuilder
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+class SignalApiImplTest {
+
+  @Mock
+  private lateinit var runtimeService: RuntimeService
+
+  private lateinit var signalApi: SignalApiImpl
+
+  @BeforeEach
+  fun setUp() {
+    signalApi = SignalApiImpl(
+      runtimeService = runtimeService,
+      commandExecutor = EngineCommandExecutor { it.run() }
+    )
+  }
+
+  @Test
+  fun `should send signal and return completedFuture`() {
+    val signalBuilder = mock<SignalEventReceivedBuilder>()
+    val payload = mapOf("key" to "value")
+    val cmd = SendSignalCmd(signalName = "mySignal", payloadSupplier = { payload })
+    whenever(runtimeService.createSignalEvent(any())).thenReturn(signalBuilder)
+    whenever(signalBuilder.setVariables(any())).thenReturn(signalBuilder)
+    doAnswer { }.whenever(signalBuilder).send()
+
+    val future = signalApi.sendSignal(cmd = cmd).get()
+
+    assertThat(future).isEqualTo(Empty)
+    verify(runtimeService).createSignalEvent("mySignal")
+    verify(signalBuilder).setVariables(payload)
+    verify(signalBuilder).send()
+    verifyNoMoreInteractions(signalBuilder)
+  }
+}

--- a/engine-adapter/cib-seven-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/deploy/DeploymentApiImplTest.kt
+++ b/engine-adapter/cib-seven-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/deploy/DeploymentApiImplTest.kt
@@ -1,5 +1,6 @@
 package dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.deploy
 
+import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.shared.EngineCommandExecutor
 import dev.bpmcrafters.processengineapi.deploy.DeployBundleCommand
 import dev.bpmcrafters.processengineapi.deploy.NamedResource
 import org.assertj.core.api.Assertions.assertThat
@@ -13,11 +14,12 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import java.util.*
+import java.util.concurrent.Executor
 
 class DeploymentApiImplTest {
 
   private val repositoryService: RepositoryService = mock()
-  private val deploymentApiImpl = DeploymentApiImpl(repositoryService)
+  private val deploymentApiImpl = DeploymentApiImpl(repositoryService, EngineCommandExecutor(Executor { it.run() }))
 
   @Test
   fun `empty tenant id was not set`() {

--- a/engine-adapter/cib-seven-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/process/Cib7EmbeddedProcessTestHelper.kt
+++ b/engine-adapter/cib-seven-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/process/Cib7EmbeddedProcessTestHelper.kt
@@ -1,5 +1,6 @@
 package dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.process
 
+import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.shared.EngineCommandExecutor
 import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.task.completion.Cib7ServiceTaskCompletionApiImpl
 import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.task.completion.Cib7UserTaskCompletionApiImpl
 import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.task.completion.LinearMemoryFailureRetrySupplier
@@ -45,6 +46,7 @@ class Cib7EmbeddedProcessTestHelper(
   override fun getStartProcessApi(): StartProcessApi = StartProcessApiImpl(
     runtimeService = processEngine.runtimeService,
     repositoryService = processEngine.repositoryService,
+    commandExecutor = EngineCommandExecutor { it.run() }
   )
 
   override fun getTaskSubscriptionApi(): TaskSubscriptionApi = Cib7TaskSubscriptionApiImpl(

--- a/engine-adapter/cib-seven-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/process/StartProcessApiImplTest.kt
+++ b/engine-adapter/cib-seven-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/process/StartProcessApiImplTest.kt
@@ -1,6 +1,7 @@
 package dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.process
 
 import dev.bpmcrafters.processengineapi.CommonRestrictions
+import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.shared.EngineCommandExecutor
 import dev.bpmcrafters.processengineapi.process.StartProcessByDefinitionAtElementCmd
 import dev.bpmcrafters.processengineapi.process.StartProcessByDefinitionCmd
 import dev.bpmcrafters.processengineapi.process.StartProcessByMessageCmd
@@ -12,14 +13,13 @@ import org.cibseven.bpm.engine.runtime.ProcessInstance
 import org.cibseven.community.mockito.QueryMocks
 import org.cibseven.community.mockito.process.ProcessDefinitionFake
 import org.cibseven.community.mockito.process.ProcessInstanceFake
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.*
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.anyOrNull
-import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.whenever
 
 @ExtendWith(MockitoExtension::class)
@@ -31,8 +31,16 @@ class StartProcessApiImplTest {
   @Mock
   private lateinit var runtimeService: RuntimeService
 
-  @InjectMocks
   private lateinit var startProcessApi: StartProcessApiImpl
+
+  @BeforeEach
+  fun setUp() {
+    startProcessApi = StartProcessApiImpl(
+      runtimeService = runtimeService,
+      repositoryService = repositoryService,
+      commandExecutor = EngineCommandExecutor { it.run() }
+    )
+  }
 
   @Test
   fun `should start process via definition without payload`() {

--- a/engine-adapter/cib-seven-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/shared/EngineCommandExecutorTest.kt
+++ b/engine-adapter/cib-seven-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/shared/EngineCommandExecutorTest.kt
@@ -1,0 +1,32 @@
+package dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.shared
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.util.concurrent.ExecutionException
+
+class EngineCommandExecutorTest {
+
+  private val directExecutor = EngineCommandExecutor { it.run() }
+
+  @Test
+  fun `execute returns supplier result`() {
+    assertThat(directExecutor.execute { 42 }.get()).isEqualTo(42)
+  }
+
+  @Test
+  fun `execute completes future exceptionally on supplier failure`() {
+    val future = directExecutor.execute<Int> { error("boom") }
+    assertThatThrownBy { future.get() }
+      .isInstanceOf(ExecutionException::class.java)
+      .hasCauseInstanceOf(IllegalStateException::class.java)
+      .hasMessageContaining("boom")
+  }
+
+  @Test
+  fun `default executor runs supplier on a different thread`() {
+    val callerThread = Thread.currentThread().name
+    val executorThread = EngineCommandExecutor().execute { Thread.currentThread().name }.get()
+    assertThat(executorThread).isNotEqualTo(callerThread)
+  }
+}

--- a/engine-adapter/cib-seven-embedded-spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/springboot/Cib7EmbeddedAdapterAutoConfiguration.kt
+++ b/engine-adapter/cib-seven-embedded-spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/springboot/Cib7EmbeddedAdapterAutoConfiguration.kt
@@ -1,28 +1,29 @@
 package dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.springboot
 
-import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.springboot.conditions.Cib7EmbeddedAdapterEnabledCondition
 import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.correlation.CorrelationApiImpl
 import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.correlation.SignalApiImpl
 import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.deploy.DeploymentApiImpl
 import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.process.StartProcessApiImpl
+import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.shared.EngineCommandExecutor
+import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.springboot.conditions.Cib7EmbeddedAdapterEnabledCondition
 import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.task.completion.Cib7ServiceTaskCompletionApiImpl
 import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.task.completion.Cib7UserTaskCompletionApiImpl
 import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.task.completion.FailureRetrySupplier
 import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.task.completion.LinearMemoryFailureRetrySupplier
 import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.task.modification.Cib7UserTaskModificationApiImpl
 import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.task.subscription.Cib7TaskSubscriptionApiImpl
-import io.toolisticon.spring.condition.ConditionalOnMissingQualifiedBean
-import dev.bpmcrafters.processengineapi.impl.task.InMemSubscriptionRepository
-import dev.bpmcrafters.processengineapi.impl.task.SubscriptionRepository
 import dev.bpmcrafters.processengineapi.correlation.CorrelationApi
 import dev.bpmcrafters.processengineapi.correlation.SignalApi
 import dev.bpmcrafters.processengineapi.deploy.DeploymentApi
+import dev.bpmcrafters.processengineapi.impl.task.InMemSubscriptionRepository
+import dev.bpmcrafters.processengineapi.impl.task.SubscriptionRepository
 import dev.bpmcrafters.processengineapi.process.StartProcessApi
 import dev.bpmcrafters.processengineapi.task.ServiceTaskCompletionApi
 import dev.bpmcrafters.processengineapi.task.TaskSubscriptionApi
 import dev.bpmcrafters.processengineapi.task.UserTaskCompletionApi
 import dev.bpmcrafters.processengineapi.task.UserTaskModificationApi
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.toolisticon.spring.condition.ConditionalOnMissingQualifiedBean
 import jakarta.annotation.PostConstruct
 import org.cibseven.bpm.engine.ExternalTaskService
 import org.cibseven.bpm.engine.RepositoryService
@@ -49,11 +50,20 @@ class Cib7EmbeddedAdapterAutoConfiguration {
     logger.debug { "PROCESS-ENGINE-CIB7-EMBEDDED-200: Configuration of services applied." }
   }
 
+  @Bean
+  @ConditionalOnMissingBean
+  fun engineCommandExecutor(): EngineCommandExecutor = EngineCommandExecutor()
+
   @Bean("cib7embedded-start-process-api")
   @Qualifier("cib7embedded-start-process-api")
-  fun startProcessApi(runtimeService: RuntimeService, repositoryService: RepositoryService): StartProcessApi = StartProcessApiImpl(
+  fun startProcessApi(
+    runtimeService: RuntimeService,
+    repositoryService: RepositoryService,
+    commandExecutor: EngineCommandExecutor
+  ): StartProcessApi = StartProcessApiImpl(
     runtimeService = runtimeService,
-    repositoryService = repositoryService
+    repositoryService = repositoryService,
+    commandExecutor = commandExecutor
   )
 
   @Bean("cib7embedded-task-subscription-api")
@@ -64,20 +74,32 @@ class Cib7EmbeddedAdapterAutoConfiguration {
 
   @Bean("cib7embedded-correlation-api")
   @Qualifier("cib7embedded-correlation-api")
-  fun correlationApi(runtimeService: RuntimeService): CorrelationApi = CorrelationApiImpl(
-    runtimeService = runtimeService
+  fun correlationApi(
+    runtimeService: RuntimeService,
+    commandExecutor: EngineCommandExecutor
+  ): CorrelationApi = CorrelationApiImpl(
+    runtimeService = runtimeService,
+    commandExecutor = commandExecutor
   )
 
   @Bean("cib7embedded-signal-api")
   @Qualifier("cib7embedded-signal-api")
-  fun signalApi(runtimeService: RuntimeService): SignalApi = SignalApiImpl(
-    runtimeService = runtimeService
+  fun signalApi(
+    runtimeService: RuntimeService,
+    commandExecutor: EngineCommandExecutor
+  ): SignalApi = SignalApiImpl(
+    runtimeService = runtimeService,
+    commandExecutor = commandExecutor
   )
 
   @Bean("cib7embedded-deployment-api")
   @Qualifier("cib7embedded-deployment-api")
-  fun deploymentApi(repositoryService: RepositoryService): DeploymentApi = DeploymentApiImpl(
-    repositoryService = repositoryService
+  fun deploymentApi(
+    repositoryService: RepositoryService,
+    commandExecutor: EngineCommandExecutor
+  ): DeploymentApi = DeploymentApiImpl(
+    repositoryService = repositoryService,
+    commandExecutor = commandExecutor
   )
 
   @Bean("cib7embedded-user-task-modification-api")


### PR DESCRIPTION
### Overview
- Added a engineCommandExecutor to modify behaviour of command-execution (sync / async)
- also required to modify the processDefinitionQuery in the StartProcessApi impl. 
- It contained a bug, that the return value could be `null` when no processDefinition was found. Neither was a processInstance created then
- completes #30 

## Further steps
- one could think about adding this EngineCommandExecutor to the process-engine-api root as well (providing it to all adapters centraly)