### PR TITLE
fix: log warning when no subscription matches a external task

### DIFF
--- a/engine-adapter/cib-seven-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/task/delivery/pull/EmbeddedPullServiceTaskDelivery.kt
+++ b/engine-adapter/cib-seven-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/task/delivery/pull/EmbeddedPullServiceTaskDelivery.kt
@@ -46,42 +46,43 @@ class EmbeddedPullServiceTaskDelivery(
         .execute()
         .parallelStream()
         .map { lockedTask ->
-          subscriptions
-            .firstOrNull { subscription -> subscription.matches(lockedTask) }
-            ?.let { activeSubscription ->
-              executorService.submit {  // in another thread
-                try {
-                  val taskInformation = if (deliveredTaskIds.contains(lockedTask.id)
-                    && subscriptionRepository.getActiveSubscriptionForTask(lockedTask.id) == activeSubscription
-                  ) {
-                    // task is already delivered to the current subscription, nothing to do
-                    null
-                  } else {
-                    // create task information and set up the reason
-                    lockedTask.toTaskInformation().withReason(TaskInformation.CREATE)
-                  }
-                  if (taskInformation != null) {
-                    subscriptionRepository.activateSubscriptionForTask(lockedTask.id, activeSubscription)
-                    val variables = lockedTask.variables.filterBySubscription(activeSubscription)
-                    logger.debug { "PROCESS-ENGINE-CIB7-EMBEDDED-031: delivering service task ${lockedTask.id}." }
-                    activeSubscription.action.accept(taskInformation, variables)
-                    logger.debug { "PROCESS-ENGINE-CIB7-EMBEDDED-032: successfully delivered service task ${lockedTask.id}." }
-                  } else {
-                    logger.trace { "PROCESS-ENGINE-CIB7-EMBEDDED-041: skipping task ${lockedTask.id} since it is unchanged." }
-                  }
-                  // remove from already delivered
-                  deliveredTaskIds.remove(lockedTask.id)
-                } catch (e: Exception) {
-                  val jobRetries: Int = lockedTask.retries ?: retries
-                  logger.error { "PROCESS-ENGINE-CIB7-EMBEDDED-033: failing delivering task ${lockedTask.id}: ${e.message}" }
-                  externalTaskService.handleFailure(lockedTask.id, workerId, e.message, jobRetries - 1, retryTimeoutInSeconds * 1000)
-                  subscriptionRepository.deactivateSubscriptionForTask(taskId = lockedTask.id)
-                  logger.error { "PROCESS-ENGINE-CIB7-EMBEDDED-034: successfully failed delivering task ${lockedTask.id}: ${e.message}" }
-                }
+          val activeSubscription = subscriptions.firstOrNull { subscription -> subscription.matches(lockedTask) }
+          if (activeSubscription == null) {
+            logger.warn { "PROCESS-ENGINE-CIB7-EMBEDDED-036: no subscription found for fetched task ${lockedTask.id} with topic '${lockedTask.topicName}'." }
+            return@map null
+          }
+          executorService.submit {  // in another thread
+            try {
+              val taskInformation = if (deliveredTaskIds.contains(lockedTask.id)
+                && subscriptionRepository.getActiveSubscriptionForTask(lockedTask.id) == activeSubscription
+              ) {
+                // task is already delivered to the current subscription, nothing to do
+                null
+              } else {
+                // create task information and set up the reason
+                lockedTask.toTaskInformation().withReason(TaskInformation.CREATE)
               }
+              if (taskInformation != null) {
+                subscriptionRepository.activateSubscriptionForTask(lockedTask.id, activeSubscription)
+                val variables = lockedTask.variables.filterBySubscription(activeSubscription)
+                logger.debug { "PROCESS-ENGINE-CIB7-EMBEDDED-031: delivering service task ${lockedTask.id}." }
+                activeSubscription.action.accept(taskInformation, variables)
+                logger.debug { "PROCESS-ENGINE-CIB7-EMBEDDED-032: successfully delivered service task ${lockedTask.id}." }
+              } else {
+                logger.trace { "PROCESS-ENGINE-CIB7-EMBEDDED-041: skipping task ${lockedTask.id} since it is unchanged." }
+              }
+              // remove from already delivered
+              deliveredTaskIds.remove(lockedTask.id)
+            } catch (e: Exception) {
+              val jobRetries: Int = lockedTask.retries ?: retries
+              logger.error { "PROCESS-ENGINE-CIB7-EMBEDDED-033: failing delivering task ${lockedTask.id}: ${e.message}" }
+              externalTaskService.handleFailure(lockedTask.id, workerId, e.message, jobRetries - 1, retryTimeoutInSeconds * 1000)
+              subscriptionRepository.deactivateSubscriptionForTask(taskId = lockedTask.id)
+              logger.error { "PROCESS-ENGINE-CIB7-EMBEDDED-034: successfully failed delivering task ${lockedTask.id}: ${e.message}" }
             }
+          }
         }.forEach { taskExecutionFuture ->
-          taskExecutionFuture.get()
+          taskExecutionFuture?.get()
         }
 
       // now we removed all still existing task ids from the list of already delivered

--- a/engine-adapter/cib-seven-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/task/delivery/pull/EmbeddedPullServiceTaskDelivery.kt
+++ b/engine-adapter/cib-seven-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/task/delivery/pull/EmbeddedPullServiceTaskDelivery.kt
@@ -48,7 +48,7 @@ class EmbeddedPullServiceTaskDelivery(
         .map { lockedTask ->
           val activeSubscription = subscriptions.firstOrNull { subscription -> subscription.matches(lockedTask) }
           if (activeSubscription == null) {
-            logger.warn { "PROCESS-ENGINE-CIB7-EMBEDDED-036: no subscription found for fetched task ${lockedTask.id} with topic '${lockedTask.topicName}'." }
+            logger.warn { "PROCESS-ENGINE-CIB7-EMBEDDED-044: no subscription found for fetched task ${lockedTask.id} with topic '${lockedTask.topicName}'." }
             return@map null
           }
           executorService.submit {  // in another thread


### PR DESCRIPTION
fix(embedded): log warning when no subscription matches a fetched external task

When the adapter polls for external service tasks and the engine returns
a task for which no subscription is registered, the refresh() cycle now
emits a warning log message instead of silently short-circuiting or
throwing a NullPointerException.

The fix replaces the ?.let pattern with an explicit null-check that logs
PROCESS-ENGINE-CIB7-EMBEDDED-036 and skips the task gracefully. The
forEach step is updated to handle the resulting nullable futures.

Closes #39