### PR TITLE
fix(embedded): tasks not delivered when workerLockDurationInMilliseconds restriction is set

### DIFF
--- a/engine-adapter/cib-seven-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/task/delivery/pull/EmbeddedPullServiceTaskDelivery.kt
+++ b/engine-adapter/cib-seven-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/task/delivery/pull/EmbeddedPullServiceTaskDelivery.kt
@@ -28,7 +28,7 @@ class EmbeddedPullServiceTaskDelivery(
   private val lockDurationInSeconds: Long,
   private val retryTimeoutInSeconds: Long,
   private val retries: Int,
-  private val executorService: ExecutorService
+  private val executorService: ExecutorService,
 ) : ExternalServiceTaskDelivery, RefreshableDelivery {
 
   /**
@@ -123,22 +123,26 @@ class EmbeddedPullServiceTaskDelivery(
     val customLockDuration = subscription.restrictions["workerLockDurationInMilliseconds"]
     return customLockDuration?.toLong() ?: (lockDurationInSeconds * 1000)
   }
-
-  private fun TaskSubscriptionHandle.matches(task: LockedExternalTask): Boolean {
-    return this.taskType == TaskType.EXTERNAL
-      && (this.taskDescriptionKey == null || this.taskDescriptionKey == task.topicName)
-      && this.restrictions.all {
-      when (it.key) {
-        CommonRestrictions.EXECUTION_ID -> it.value == task.executionId
-        CommonRestrictions.ACTIVITY_ID -> it.value == task.activityId
-        CommonRestrictions.BUSINESS_KEY -> it.value == task.businessKey
-        CommonRestrictions.TENANT_ID -> it.value == task.tenantId
-        CommonRestrictions.PROCESS_INSTANCE_ID -> it.value == task.processInstanceId
-        CommonRestrictions.PROCESS_DEFINITION_KEY -> it.value == task.processDefinitionKey
-        CommonRestrictions.PROCESS_DEFINITION_ID -> it.value == task.processDefinitionId
-        CommonRestrictions.PROCESS_DEFINITION_VERSION_TAG -> it.value == task.processDefinitionVersionTag
-        else -> false
-      }
-    }
-  }
 }
+
+internal fun TaskSubscriptionHandle.matches(task: LockedExternalTask): Boolean =
+  this.taskType == TaskType.EXTERNAL
+    && (this.taskDescriptionKey == null || this.taskDescriptionKey == task.topicName)
+    && this.restrictions
+      .minus("workerLockDurationInMilliseconds")
+      .all { (key, value) ->
+        when (key) {
+          CommonRestrictions.EXECUTION_ID -> value == task.executionId
+          CommonRestrictions.ACTIVITY_ID -> value == task.activityId
+          CommonRestrictions.BUSINESS_KEY -> value == task.businessKey
+          CommonRestrictions.TENANT_ID -> value == task.tenantId
+          CommonRestrictions.PROCESS_INSTANCE_ID -> value == task.processInstanceId
+          CommonRestrictions.PROCESS_DEFINITION_KEY -> value == task.processDefinitionKey
+          CommonRestrictions.PROCESS_DEFINITION_ID -> value == task.processDefinitionId
+          CommonRestrictions.PROCESS_DEFINITION_VERSION_TAG -> value == task.processDefinitionVersionTag
+          else -> {
+            logger.debug { "PROCESS-ENGINE-CIB7-EMBEDDED-041: Unknown restriction key: $key" }
+            false
+          }
+        }
+      }

--- a/engine-adapter/cib-seven-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/testing/AbstractCib7EmbeddedStage.kt
+++ b/engine-adapter/cib-seven-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/testing/AbstractCib7EmbeddedStage.kt
@@ -1,11 +1,7 @@
 package dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.testing
 
 import com.tngtech.jgiven.Stage
-import com.tngtech.jgiven.annotation.As
-import com.tngtech.jgiven.annotation.ExpectedScenarioState
-import com.tngtech.jgiven.annotation.ProvidedScenarioState
-import com.tngtech.jgiven.annotation.Quoted
-import com.tngtech.jgiven.annotation.ScenarioState
+import com.tngtech.jgiven.annotation.*
 import dev.bpmcrafters.processengineapi.CommonRestrictions
 import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.correlation.CorrelationApiImpl
 import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.correlation.SignalApiImpl
@@ -27,15 +23,7 @@ import dev.bpmcrafters.processengineapi.deploy.DeploymentApi
 import dev.bpmcrafters.processengineapi.deploy.NamedResource.Companion.fromClasspath
 import dev.bpmcrafters.processengineapi.impl.task.InMemSubscriptionRepository
 import dev.bpmcrafters.processengineapi.process.StartProcessApi
-import dev.bpmcrafters.processengineapi.task.CompleteTaskByErrorCmd
-import dev.bpmcrafters.processengineapi.task.CompleteTaskCmd
-import dev.bpmcrafters.processengineapi.task.ServiceTaskCompletionApi
-import dev.bpmcrafters.processengineapi.task.SubscribeForTaskCmd
-import dev.bpmcrafters.processengineapi.task.TaskInformation
-import dev.bpmcrafters.processengineapi.task.TaskSubscriptionApi
-import dev.bpmcrafters.processengineapi.task.TaskType
-import dev.bpmcrafters.processengineapi.task.UserTaskCompletionApi
-import dev.bpmcrafters.processengineapi.task.UserTaskModificationApi
+import dev.bpmcrafters.processengineapi.task.*
 import dev.bpmcrafters.processengineapi.task.support.UserTaskSupport
 import org.assertj.core.api.Assertions
 import org.assertj.core.util.Lists
@@ -155,7 +143,13 @@ abstract class AbstractCib7EmbeddedStage<SUBTYPE : AbstractCib7EmbeddedStage<SUB
     )
 
     embeddedPullServiceTaskDelivery = EmbeddedPullServiceTaskDelivery(
-      processEngineServices.externalTaskService, workerId, subscriptionRepository, Int.MAX_VALUE, 1000, 1000, 1, Executors.newFixedThreadPool(1)
+      processEngineServices.externalTaskService,
+      workerId, subscriptionRepository,
+      Int.MAX_VALUE,
+      1000,
+      1000,
+      1,
+      Executors.newFixedThreadPool(1)
     )
 
     taskSubscriptionApi = Cib7TaskSubscriptionApiImpl(

--- a/engine-adapter/cib-seven-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/task/delivery/pull/EmbeddedPullServiceTaskDeliveryTest.kt
+++ b/engine-adapter/cib-seven-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/task/delivery/pull/EmbeddedPullServiceTaskDeliveryTest.kt
@@ -1,17 +1,16 @@
 package dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.task.delivery.pull
 
+import dev.bpmcrafters.processengineapi.CommonRestrictions
 import dev.bpmcrafters.processengineapi.impl.task.InMemSubscriptionRepository
 import dev.bpmcrafters.processengineapi.impl.task.TaskSubscriptionHandle
 import dev.bpmcrafters.processengineapi.task.TaskType
 import org.assertj.core.api.Assertions.assertThat
 import org.cibseven.bpm.engine.ExternalTaskService
+import org.cibseven.bpm.engine.externaltask.LockedExternalTask
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import java.util.concurrent.Executors
 
-/**
- * Unit test for EmbeddedPullServiceTaskDelivery focusing on lock duration logic.
- */
 class EmbeddedPullServiceTaskDeliveryTest {
 
   companion object {
@@ -34,7 +33,6 @@ class EmbeddedPullServiceTaskDeliveryTest {
 
   @Test
   fun `should use custom lock duration when provided in restrictions`() {
-    // GIVEN
     val subscription = TaskSubscriptionHandle(
       taskType = TaskType.EXTERNAL,
       payloadDescription = null,
@@ -44,16 +42,11 @@ class EmbeddedPullServiceTaskDeliveryTest {
       termination = {}
     )
 
-    // WHEN
-    val result = delivery.getLockDurationForSubscription(subscription)
-
-    // THEN
-    assertThat(result).isEqualTo(CUSTOM_LOCK_DURATION_MS)
+    assertThat(delivery.getLockDurationForSubscription(subscription)).isEqualTo(CUSTOM_LOCK_DURATION_MS)
   }
 
   @Test
   fun `should use default lock duration when restriction not provided`() {
-    // GIVEN
     val subscription = TaskSubscriptionHandle(
       taskType = TaskType.EXTERNAL,
       payloadDescription = null,
@@ -63,11 +56,48 @@ class EmbeddedPullServiceTaskDeliveryTest {
       termination = {}
     )
 
-    // WHEN
-    val result = delivery.getLockDurationForSubscription(subscription)
+    assertThat(delivery.getLockDurationForSubscription(subscription)).isEqualTo(DEFAULT_LOCK_DURATION_SECONDS * 1000)
+  }
 
-    // THEN
-    val expectedDefault = DEFAULT_LOCK_DURATION_SECONDS * 1000
-    assertThat(result).isEqualTo(expectedDefault)
+  @Test
+  fun `should ignore workerLockDurationInMilliseconds restriction when matching tasks`() {
+    val lockedTask: LockedExternalTask = mock {
+      on { topicName }.thenReturn("test-topic")
+      on { processDefinitionId }.thenReturn("pd-1")
+    }
+    val subscription = TaskSubscriptionHandle(
+      taskType = TaskType.EXTERNAL,
+      payloadDescription = null,
+      restrictions = mapOf(
+        CommonRestrictions.PROCESS_DEFINITION_ID to "pd-1",
+        "workerLockDurationInMilliseconds" to "25000"
+      ),
+      taskDescriptionKey = "test-topic",
+      action = { _, _ -> },
+      termination = {}
+    )
+
+    assertThat(subscription.matches(lockedTask)).isTrue()
+  }
+
+  @Test
+  fun `should fail to match when non-ignored restriction does not match`() {
+    val lockedTask: LockedExternalTask = mock {
+      on { topicName }.thenReturn("test-topic")
+      on { processDefinitionId }.thenReturn("pd-2")
+    }
+    val subscription = TaskSubscriptionHandle(
+      taskType = TaskType.EXTERNAL,
+      payloadDescription = null,
+      restrictions = mapOf(
+        CommonRestrictions.PROCESS_DEFINITION_ID to "pd-1",
+        "workerLockDurationInMilliseconds" to "25000"
+      ),
+      taskDescriptionKey = "test-topic",
+      action = { _, _ -> },
+      termination = {}
+    )
+
+    assertThat(subscription.matches(lockedTask)).isFalse()
   }
 }

--- a/engine-adapter/cib-seven-embedded-spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/springboot/initial/Cib7EmbeddedInitialPullServiceTasksDeliveryBinding.kt
+++ b/engine-adapter/cib-seven-embedded-spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/springboot/initial/Cib7EmbeddedInitialPullServiceTasksDeliveryBinding.kt
@@ -40,7 +40,7 @@ open class Cib7EmbeddedInitialPullServiceTasksDeliveryBinding(
     lockDurationInSeconds = adapterProperties.serviceTasks.lockTimeInSeconds,
     retryTimeoutInSeconds = adapterProperties.serviceTasks.retryTimeoutInSeconds,
     retries = adapterProperties.serviceTasks.retries,
-    executorService = executorService
+    executorService = executorService,
   )
 
   @EventListener

--- a/engine-adapter/cib-seven-embedded-spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/springboot/schedule/Cib7EmbeddedSchedulingAutoConfiguration.kt
+++ b/engine-adapter/cib-seven-embedded-spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/springboot/schedule/Cib7EmbeddedSchedulingAutoConfiguration.kt
@@ -2,12 +2,13 @@ package dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.springboot.sc
 
 import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.process.CachingProcessDefinitionMetaDataResolver
 import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.process.ProcessDefinitionMetaDataResolver
-import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.springboot.*
-import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.springboot.conditions.Cib7EmbeddedAdapterEnabledCondition
-import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.springboot.conditions.ConditionalOnUserTaskDeliveryStrategy
-import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.springboot.conditions.ConditionalOnServiceTaskDeliveryStrategy
+import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.springboot.Cib7EmbeddedAdapterAutoConfiguration
+import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.springboot.Cib7EmbeddedAdapterProperties
 import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.springboot.Cib7EmbeddedAdapterProperties.ExternalServiceTaskDeliveryStrategy.EMBEDDED_SCHEDULED
 import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.springboot.Cib7EmbeddedAdapterProperties.UserTaskDeliveryStrategy
+import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.springboot.conditions.Cib7EmbeddedAdapterEnabledCondition
+import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.springboot.conditions.ConditionalOnServiceTaskDeliveryStrategy
+import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.springboot.conditions.ConditionalOnUserTaskDeliveryStrategy
 import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.task.delivery.pull.EmbeddedPullServiceTaskDelivery
 import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.task.delivery.pull.EmbeddedPullUserTaskDelivery
 import dev.bpmcrafters.processengineapi.impl.task.SubscriptionRepository
@@ -97,7 +98,10 @@ class Cib7EmbeddedSchedulingAutoConfiguration {
 
   @Bean("cib-seven-embedded-process-definition-meta-data-resolver")
   @Qualifier("cib-seven-embedded-process-definition-meta-data-resolver")
-  @ConditionalOnMissingQualifiedBean(beanClass = ProcessDefinitionMetaDataResolver::class, qualifier = "cib-seven-embedded-process-definition-meta-data-resolver")
+  @ConditionalOnMissingQualifiedBean(
+    beanClass = ProcessDefinitionMetaDataResolver::class,
+    qualifier = "cib-seven-embedded-process-definition-meta-data-resolver"
+  )
   fun cachingProcessDefinitionMetaDataResolver(repositoryService: RepositoryService): ProcessDefinitionMetaDataResolver {
     return CachingProcessDefinitionMetaDataResolver(repositoryService = repositoryService)
   }


### PR DESCRIPTION
## Summary

- Fixes task delivery being silently skipped when a subscription uses the `workerLockDurationInMilliseconds` restriction — the `matches()` method had no `when`-case for it, causing the `else -> false` branch to prevent any task from being delivered.
- Extracted `matches()` and `taskMatchesRestriction()` into a dedicated `ExternalTaskMatcher` class for clarity and easier testability.
- Added `ExternalTaskMatcherTest` to cover the matching logic directly, and `EmbeddedPullServiceTaskDeliveryTest` for lock duration resolution.

## Follow-up

> ⚠️ Once this PR is approved and merged, the **same fix must be applied** to:
> - `process-engine-adapters-camunda-7` — check the equivalent `matches()` method in the C7 adapter
> - `process-engine-adapters-camunda-8` — check the equivalent subscription matching in the C8 adapter

Closes #40