### PR TITLE
ci(dependabot): assign update PRs to maintainer, schedule actions weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,15 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 19
+    assignees:
+      - "emaarco"
     labels:
       - "Type: dependencies"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    assignees:
+      - "emaarco"
     labels:
       - "Type: dependencies"


### PR DESCRIPTION
## Summary
- Assign all Dependabot dependency-update PRs to `emaarco` (both `maven` and `github-actions` ecosystems)
- Change the `github-actions` update schedule from `daily` to `weekly`

## Notes
- The `maven` ecosystem was already on a `weekly` schedule; only the assignee was added there.