### PR TITLE
refactor: use WORKER_LOCK_DURATION_IN_MILLISECONDS constant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ _tmp/
 .repository/
 .DS_Store
 .claude
+.claude/logs/

--- a/engine-adapter/cib-seven-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/task/delivery/pull/EmbeddedPullServiceTaskDelivery.kt
+++ b/engine-adapter/cib-seven-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/task/delivery/pull/EmbeddedPullServiceTaskDelivery.kt
@@ -120,7 +120,7 @@ class EmbeddedPullServiceTaskDelivery(
   }
 
   internal fun getLockDurationForSubscription(subscription: TaskSubscriptionHandle): Long {
-    val customLockDuration = subscription.restrictions["workerLockDurationInMilliseconds"]
+    val customLockDuration = subscription.restrictions[CommonRestrictions.WORKER_LOCK_DURATION_IN_MILLISECONDS]
     return customLockDuration?.toLong() ?: (lockDurationInSeconds * 1000)
   }
 }
@@ -129,7 +129,7 @@ internal fun TaskSubscriptionHandle.matches(task: LockedExternalTask): Boolean =
   this.taskType == TaskType.EXTERNAL
     && (this.taskDescriptionKey == null || this.taskDescriptionKey == task.topicName)
     && this.restrictions
-      .minus("workerLockDurationInMilliseconds")
+      .minus(CommonRestrictions.WORKER_LOCK_DURATION_IN_MILLISECONDS)
       .all { (key, value) ->
         when (key) {
           CommonRestrictions.EXECUTION_ID -> value == task.executionId

--- a/engine-adapter/cib-seven-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/task/delivery/pull/EmbeddedPullServiceTaskDeliveryTest.kt
+++ b/engine-adapter/cib-seven-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/task/delivery/pull/EmbeddedPullServiceTaskDeliveryTest.kt
@@ -36,7 +36,7 @@ class EmbeddedPullServiceTaskDeliveryTest {
     val subscription = TaskSubscriptionHandle(
       taskType = TaskType.EXTERNAL,
       payloadDescription = null,
-      restrictions = mapOf("workerLockDurationInMilliseconds" to CUSTOM_LOCK_DURATION_MS.toString()),
+      restrictions = mapOf(CommonRestrictions.WORKER_LOCK_DURATION_IN_MILLISECONDS to CUSTOM_LOCK_DURATION_MS.toString()),
       taskDescriptionKey = "custom-topic",
       action = { _, _ -> },
       termination = {}
@@ -70,7 +70,7 @@ class EmbeddedPullServiceTaskDeliveryTest {
       payloadDescription = null,
       restrictions = mapOf(
         CommonRestrictions.PROCESS_DEFINITION_ID to "pd-1",
-        "workerLockDurationInMilliseconds" to "25000"
+        CommonRestrictions.WORKER_LOCK_DURATION_IN_MILLISECONDS to "25000"
       ),
       taskDescriptionKey = "test-topic",
       action = { _, _ -> },
@@ -91,7 +91,7 @@ class EmbeddedPullServiceTaskDeliveryTest {
       payloadDescription = null,
       restrictions = mapOf(
         CommonRestrictions.PROCESS_DEFINITION_ID to "pd-1",
-        "workerLockDurationInMilliseconds" to "25000"
+        CommonRestrictions.WORKER_LOCK_DURATION_IN_MILLISECONDS to "25000"
       ),
       taskDescriptionKey = "test-topic",
       action = { _, _ -> },


### PR DESCRIPTION
## What

Replace the hardcoded `"workerLockDurationInMilliseconds"` string literal with the `CommonRestrictions.WORKER_LOCK_DURATION_IN_MILLISECONDS` constant introduced in process-engine-api 1.6 ([bb1a250](https://github.com/bpm-crafters/process-engine-api/commit/bb1a25092aca40906cfbdcb77960011c22310110)).

## Why

`EmbeddedPullServiceTaskDelivery` already imports and uses `CommonRestrictions` for the other restriction keys (`EXECUTION_ID`, `ACTIVITY_ID`, `BUSINESS_KEY`, …), but the worker-lock-duration key was still referenced as a raw string in two places. The dependency was bumped to 1.6 in #66, which now ships this constant, so the inconsistency can be removed.

## Changes

- `EmbeddedPullServiceTaskDelivery.kt`: use the constant in `getLockDurationForSubscription` and in the `matches` extension (`.minus(...)`).
- `EmbeddedPullServiceTaskDeliveryTest.kt`: use the constant for the restriction map keys.
- `.gitignore`: ignore `.claude/logs/`.

## Verification

`mvn -pl engine-adapter/cib-seven-embedded-core -am test` → BUILD SUCCESS, 49 tests pass.