### PR TITLE
feat: map business key into delivered task meta data

### DIFF
--- a/engine-adapter/cib-seven-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/task/delivery/TaskInformationExtensions.kt
+++ b/engine-adapter/cib-seven-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/task/delivery/TaskInformationExtensions.kt
@@ -16,7 +16,8 @@ import java.util.*
 fun Task.toTaskInformation(candidates: Set<IdentityLink>, processDefinitionKey: String? = null) =
   TaskInformation(
     taskId = this.id,
-    meta = mapOf(
+    meta = metaOf(
+      CommonRestrictions.PROCESS_DEFINITION_KEY to processDefinitionKey,
       CommonRestrictions.PROCESS_DEFINITION_ID to this.processDefinitionId,
       CommonRestrictions.ACTIVITY_ID to this.taskDefinitionKey,
       CommonRestrictions.TENANT_ID to this.tenantId,
@@ -31,23 +32,18 @@ fun Task.toTaskInformation(candidates: Set<IdentityLink>, processDefinitionKey: 
       "candidateUsers" to candidates.toUsersString(),
       "candidateGroups" to candidates.toGroupsString(),
       "lastUpdatedDate" to this.lastUpdated.toDateString()
-    ).let {
-      if (processDefinitionKey != null) {
-        it + (CommonRestrictions.PROCESS_DEFINITION_KEY to processDefinitionKey)
-      } else {
-        it
-      }
-    }
+    )
   )
 
 fun DelegateTask.toTaskInformation() =
   TaskInformation(
     taskId = this.id,
-    meta = mapOf(
+    meta = metaOf(
       CommonRestrictions.PROCESS_DEFINITION_ID to this.processDefinitionId,
       CommonRestrictions.ACTIVITY_ID to this.taskDefinitionKey,
       CommonRestrictions.TENANT_ID to this.tenantId,
       CommonRestrictions.PROCESS_INSTANCE_ID to this.processInstanceId,
+      CommonRestrictions.BUSINESS_KEY to this.variables?.get(CommonRestrictions.BUSINESS_KEY)?.toString(),
       "taskName" to this.name,
       "taskDescription" to this.description,
       "assignee" to this.assignee,
@@ -63,22 +59,34 @@ fun DelegateTask.toTaskInformation() =
 fun LockedExternalTask.toTaskInformation(): TaskInformation =
   TaskInformation(
     taskId = this.id,
-    meta = mapOf(
+    meta = metaOf(
       CommonRestrictions.ACTIVITY_ID to this.activityId,
       CommonRestrictions.PROCESS_DEFINITION_ID to this.processDefinitionId,
       CommonRestrictions.PROCESS_DEFINITION_KEY to this.processDefinitionKey,
       CommonRestrictions.PROCESS_INSTANCE_ID to this.processInstanceId,
       CommonRestrictions.TENANT_ID to this.tenantId,
+      CommonRestrictions.BUSINESS_KEY to this.businessKey,
       "topicName" to this.topicName,
       "creationDate" to this.createTime.toDateString(),
-      TaskInformation.RETRIES to (this.retries?.toString() ?: ""),
+      TaskInformation.RETRIES to this.retries?.toString(),
     )
   )
 
 /**
+ * Creates a map of the provided pairs, dropping any pair whose value is `null`.
+ */
+fun metaOf(vararg pairs: Pair<String, String?>): Map<String, String> =
+  sequenceOf(*pairs)
+    .filter { it.second != null }
+    .associate {
+      @Suppress("UNCHECKED_CAST")
+      it as Pair<String, String>
+    }
+
+/**
  * Converts engine internal representation into a string.
  */
-fun Date?.toDateString() = this?.toInstant()?.toIso8601() ?: ""
+fun Date?.toDateString() = this?.toInstant()?.toIso8601()
 
 /**
  * Converts to offset date time in ISO8601 in UTC.

--- a/engine-adapter/cib-seven-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/task/delivery/TaskInformationExtensionsKtTest.kt
+++ b/engine-adapter/cib-seven-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/task/delivery/TaskInformationExtensionsKtTest.kt
@@ -6,14 +6,18 @@ import org.cibseven.bpm.engine.impl.persistence.entity.IdentityLinkEntity
 import org.cibseven.bpm.engine.task.IdentityLink
 import org.cibseven.community.mockito.delegate.DelegateTaskFake
 import org.cibseven.community.mockito.task.TaskFake
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.NullSource
+import org.junit.jupiter.params.provider.ValueSource
 import java.time.Instant
 import java.util.*
 
 class TaskInformationExtensionsKtTest {
 
-  @Test
-  fun `should map Task`() {
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = ["Sat, 12 Aug 1995 13:30:00 GMT+0430"])
+  fun `should map Task`(maybeNullDate: Date?) {
     val now = Date.from(Instant.now())
     val task = TaskFake.builder()
       .id("taskId")
@@ -25,10 +29,10 @@ class TaskInformationExtensionsKtTest {
       .description("description")
       .assignee("assignee")
       .createTime(now)
-      .followUpDate(now)
-      .dueDate(now)
+      .followUpDate(maybeNullDate)
+      .dueDate(maybeNullDate)
       .formKey("formKey")
-      .lastUpdated(now)
+      .lastUpdated(maybeNullDate)
       .build()
 
     val identityLinks =
@@ -45,16 +49,24 @@ class TaskInformationExtensionsKtTest {
     assertThat(taskInformation.meta["taskDescription"]).isEqualTo("description")
     assertThat(taskInformation.meta["assignee"]).isEqualTo("assignee")
     assertThat(taskInformation.meta["creationDate"]).isEqualTo(now.toDateString())
-    assertThat(taskInformation.meta["followUpDate"]).isEqualTo(now.toDateString())
-    assertThat(taskInformation.meta["dueDate"]).isEqualTo(now.toDateString())
     assertThat(taskInformation.meta["formKey"]).isEqualTo("formKey")
     assertThat(taskInformation.meta["candidateUsers"]).isEqualTo("user-1,user-2")
     assertThat(taskInformation.meta["candidateGroups"]).isEqualTo("group")
-    assertThat(taskInformation.meta["lastUpdatedDate"]).isEqualTo(now.toDateString())
+    if (maybeNullDate == null) {
+      assertThat(taskInformation.meta).doesNotContainKey("followUpDate")
+      assertThat(taskInformation.meta).doesNotContainKey("dueDate")
+      assertThat(taskInformation.meta).doesNotContainKey("lastUpdatedDate")
+    } else {
+      assertThat(taskInformation.meta["followUpDate"]).isEqualTo(maybeNullDate.toDateString())
+      assertThat(taskInformation.meta["dueDate"]).isEqualTo(maybeNullDate.toDateString())
+      assertThat(taskInformation.meta["lastUpdatedDate"]).isEqualTo(maybeNullDate.toDateString())
+    }
   }
 
-  @Test
-  fun `should map DelegateTask`() {
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = ["Sat, 12 Aug 1995 13:30:00 GMT+0430"])
+  fun `should map DelegateTask`(maybeNullDate: Date?) {
     val now = Date.from(Instant.now())
 
     var delegateTask = DelegateTaskFake("taskId")
@@ -66,9 +78,10 @@ class TaskInformationExtensionsKtTest {
     delegateTask = delegateTask.withDescription("description")
     delegateTask = delegateTask.withAssignee("assignee")
     delegateTask = delegateTask.withCreateTime(now)
-    delegateTask = delegateTask.withFollowUpDate(now)
-    delegateTask = delegateTask.withLastUpdated(now)
-    delegateTask.dueDate = now
+    delegateTask = delegateTask.withFollowUpDate(maybeNullDate)
+    delegateTask = delegateTask.withLastUpdated(maybeNullDate)
+    delegateTask = delegateTask.withVariable(CommonRestrictions.BUSINESS_KEY, "businessKey")
+    delegateTask.dueDate = maybeNullDate
     delegateTask.addGroupIdentityLink("group-1", "CANDIDATE")
     delegateTask.addGroupIdentityLink("group-2", "CANDIDATE")
     delegateTask.addUserIdentityLink("user-1", "CANDIDATE")
@@ -80,17 +93,23 @@ class TaskInformationExtensionsKtTest {
     assertThat(taskInformation.meta[CommonRestrictions.PROCESS_DEFINITION_ID]).isEqualTo("processDefinitionId")
     assertThat(taskInformation.meta[CommonRestrictions.ACTIVITY_ID]).isEqualTo("taskDefinitionKey")
     assertThat(taskInformation.meta[CommonRestrictions.TENANT_ID]).isEqualTo("tenantId")
+    assertThat(taskInformation.meta[CommonRestrictions.BUSINESS_KEY]).isEqualTo("businessKey")
     assertThat(taskInformation.meta["taskName"]).isEqualTo("name")
     assertThat(taskInformation.meta["taskDescription"]).isEqualTo("description")
     assertThat(taskInformation.meta["assignee"]).isEqualTo("assignee")
     assertThat(taskInformation.meta["creationDate"]).isEqualTo(now.toDateString())
-    assertThat(taskInformation.meta["followUpDate"]).isEqualTo(now.toDateString())
-    assertThat(taskInformation.meta["dueDate"]).isEqualTo(now.toDateString())
     assertThat(taskInformation.meta["formKey"]).isNull()
     assertThat(taskInformation.meta["candidateUsers"]).isEqualTo("user-1,user-2")
     assertThat(taskInformation.meta["candidateGroups"]).isEqualTo("group-1,group-2")
+    if (maybeNullDate == null) {
+      assertThat(taskInformation.meta).doesNotContainKey("followUpDate")
+      assertThat(taskInformation.meta).doesNotContainKey("dueDate")
+    } else {
+      assertThat(taskInformation.meta["followUpDate"]).isEqualTo(maybeNullDate.toDateString())
+      assertThat(taskInformation.meta["dueDate"]).isEqualTo(maybeNullDate.toDateString())
+    }
     // TODO: bug in cib-seven-mockito (https://github.com/cibseven-community-hub/cibseven-mockito/issues/8)
-    // assertThat(taskInformation.meta["lastUpdatedDate"]).isEqualTo(now.toDateString())
+    // lastUpdated is not reflected by DelegateTaskFake, so "lastUpdatedDate" is not asserted here.
   }
 
   private fun identityLink(userId: String? = null, groupId: String? = null): IdentityLink {


### PR DESCRIPTION
## Summary

First PR in the effort to sync the CIB Seven embedded adapter with the functional drift from upstream `process-engine-adapters-camunda-7` (tracked in #63). This PR ports **T2** and **T3**, which are mechanically coupled in the same file.

### T2 — Map business key into delivered task meta data
(upstream issue [#188](https://github.com/bpm-crafters/process-engine-adapters-camunda-7/issues/188) / PR [#189](https://github.com/bpm-crafters/process-engine-adapters-camunda-7/pull/189), rel 2026.06.1)

- Add `CommonRestrictions.BUSINESS_KEY` to the meta of `DelegateTask.toTaskInformation()` (from `variables[BUSINESS_KEY]`) and `LockedExternalTask.toTaskInformation()` (from `businessKey`).

### T3 — Drop empty strings for null meta values (`metaOf()` helper)
(upstream commit [`e0143406`](https://github.com/bpm-crafters/process-engine-adapters-camunda-7/commit/e0143406))

- Introduce a `metaOf(vararg Pair<String, String?>)` helper that filters out null values; replace all `mapOf(...)` usages with it.
- Make `Date?.toDateString()` return `null` instead of `""` (keeps the CIB Seven `toIso8601()` UTC helper).
- Remove the `?: ""` fallbacks and the `PROCESS_DEFINITION_KEY` `.let { }` workaround. Net effect: absent values are omitted from meta rather than stored as `""`.

## Scope note

- **T4** (process-engine-api 1.5 → 1.6) already landed on `develop` (commit `e7a23c2`), so no `pom.xml` change was needed here and `CommonRestrictions.BUSINESS_KEY` is already on the classpath.
- **T1** and **T5** are intentionally **not** part of this PR and remain open in #63.

## Tests

- `TaskInformationExtensionsKtTest` converted to parameterized (`@NullSource` + `@ValueSource`) per upstream: asserts the business key is present and that null date fields are **absent** (not `""`).
- **CIB Seven deviation:** `lastUpdatedDate` is still not asserted for `DelegateTask` due to the known cibseven-mockito bug ([#8](https://github.com/cibseven-community-hub/cibseven-mockito/issues/8)); a follow-up will re-enable it once the dependency is bumped.
- Full `cib-seven-embedded-core` module suite (incl. JGiven delivery ITests) is green.

Refs #63