### PR TITLE
test: re-enable lastUpdatedDate assertion for DelegateTask

### DIFF
--- a/engine-adapter/cib-seven-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/task/delivery/TaskInformationExtensionsKtTest.kt
+++ b/engine-adapter/cib-seven-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/task/delivery/TaskInformationExtensionsKtTest.kt
@@ -89,8 +89,7 @@ class TaskInformationExtensionsKtTest {
     assertThat(taskInformation.meta["formKey"]).isNull()
     assertThat(taskInformation.meta["candidateUsers"]).isEqualTo("user-1,user-2")
     assertThat(taskInformation.meta["candidateGroups"]).isEqualTo("group-1,group-2")
-    // TODO: bug in cib-seven-mockito (https://github.com/cibseven-community-hub/cibseven-mockito/issues/8)
-    // assertThat(taskInformation.meta["lastUpdatedDate"]).isEqualTo(now.toDateString())
+    assertThat(taskInformation.meta["lastUpdatedDate"]).isEqualTo(now.toDateString())
   }
 
   private fun identityLink(userId: String? = null, groupId: String? = null): IdentityLink {


### PR DESCRIPTION
## Summary

The upstream bug [cibseven-community-hub/cibseven-mockito#8](https://github.com/cibseven-community-hub/cibseven-mockito/issues/8) (`DelegateTaskFake` not reflecting `lastUpdated`) has been fixed. This re-enables the previously skipped `lastUpdatedDate` assertion in the `should map DelegateTask` test.

## Changes

- Removed the `// TODO: bug in cib-seven-mockito (...issues/8)` workaround in `TaskInformationExtensionsKtTest`.
- Enabled `assertThat(taskInformation.meta["lastUpdatedDate"]).isEqualTo(now.toDateString())`, matching how `followUpDate`/`dueDate` are asserted.

## Note on the dependency

No version bump was needed: `cibseven-mockito` is already pinned to **2.1.0**, which is the latest release on Maven Central and already contains the fix (`getLastUpdated()` returns `lastUpdated` since 2.0.0).

## Verification

- `TaskInformationExtensionsKtTest` — 2 tests, 0 failures.
- Full `cib-seven-embedded-core` module suite — **49 tests, 0 failures, BUILD SUCCESS**.