### PR TITLE
feat: add opt-in duplicate filtering for deployments

### DIFF
--- a/docs/quickstart-cib-seven-embedded.md
+++ b/docs/quickstart-cib-seven-embedded.md
@@ -35,4 +35,12 @@ dev:
             delivery-strategy: embedded_scheduled
             execute-initial-pull-on-startup: true
             schedule-delivery-fixed-rate-in-seconds: 60
+          deployment:
+            deploy-only-on-change: false
 ```
+
+## Deployment
+
+| Key                            | Value             | Description                                                                                                                                                                |
+|--------------------------------|-------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `deployment.deploy-only-on-change` | `true` or `false` | If `true`, a new deployment is only created when at least one resource actually changed; unchanged BPMN/DMN resources are not redeployed as new versions. Defaults to `false`. |

--- a/engine-adapter/cib-seven-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/deploy/DeploymentApiImpl.kt
+++ b/engine-adapter/cib-seven-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/deploy/DeploymentApiImpl.kt
@@ -18,7 +18,8 @@ private val logger = KotlinLogging.logger {}
  */
 class DeploymentApiImpl(
   private val repositoryService: RepositoryService,
-  private val commandExecutor: EngineCommandExecutor
+  private val commandExecutor: EngineCommandExecutor,
+  private val deployOnlyOnChange: Boolean = false
 ) : DeploymentApi {
 
   override fun deploy(cmd: DeployBundleCommand): CompletableFuture<DeploymentInformation> {
@@ -29,6 +30,9 @@ class DeploymentApiImpl(
         .createDeployment()
         .apply {
           cmd.resources.forEach { resource -> this.addInputStream(resource.name, resource.resourceStream) }
+          if (deployOnlyOnChange) {
+            this.enableDuplicateFiltering(true)
+          }
         }
         .apply {
           if (!cmd.tenantId.isNullOrBlank()) {

--- a/engine-adapter/cib-seven-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/deploy/DeploymentApiImplTest.kt
+++ b/engine-adapter/cib-seven-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/deploy/DeploymentApiImplTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import java.util.*
@@ -40,5 +41,42 @@ class DeploymentApiImplTest {
     assertThat(deploymentInformation.tenantId).isNull()
   }
 
+  @Test
+  fun `duplicate filtering is not enabled by default`() {
+    val deploymentBuilder = givenDeploymentBuilder()
+
+    deploymentApiImpl.deploy(
+      DeployBundleCommand(listOf(NamedResource.fromClasspath("bpmn/simple-process.bpmn")), "")
+    ).get()
+
+    verify(deploymentBuilder, never()).enableDuplicateFiltering(any())
+  }
+
+  @Test
+  fun `duplicate filtering is enabled when deployOnlyOnChange is true`() {
+    val deploymentBuilder = givenDeploymentBuilder()
+    val deployOnlyOnChangeApi = DeploymentApiImpl(
+      repositoryService,
+      EngineCommandExecutor(Executor { it.run() }),
+      deployOnlyOnChange = true
+    )
+
+    deployOnlyOnChangeApi.deploy(
+      DeployBundleCommand(listOf(NamedResource.fromClasspath("bpmn/simple-process.bpmn")), "")
+    ).get()
+
+    verify(deploymentBuilder).enableDuplicateFiltering(eq(true))
+  }
+
+  private fun givenDeploymentBuilder(): DeploymentBuilder {
+    val deploymentBuilder: DeploymentBuilder = mock()
+    given(repositoryService.createDeployment()).willReturn(deploymentBuilder)
+    val deployment: Deployment = mock()
+    given(deploymentBuilder.deploy()).willReturn(deployment)
+    given(deployment.tenantId).willReturn(null)
+    given(deployment.deploymentTime).willReturn(Date())
+    given(deployment.id).willReturn("myDeploymentId")
+    return deploymentBuilder
+  }
 
 }

--- a/engine-adapter/cib-seven-embedded-spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/springboot/Cib7EmbeddedAdapterAutoConfiguration.kt
+++ b/engine-adapter/cib-seven-embedded-spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/springboot/Cib7EmbeddedAdapterAutoConfiguration.kt
@@ -96,10 +96,12 @@ class Cib7EmbeddedAdapterAutoConfiguration {
   @Qualifier("cib7embedded-deployment-api")
   fun deploymentApi(
     repositoryService: RepositoryService,
-    commandExecutor: EngineCommandExecutor
+    commandExecutor: EngineCommandExecutor,
+    properties: Cib7EmbeddedAdapterProperties
   ): DeploymentApi = DeploymentApiImpl(
     repositoryService = repositoryService,
-    commandExecutor = commandExecutor
+    commandExecutor = commandExecutor,
+    deployOnlyOnChange = properties.deployment.deployOnlyOnChange
   )
 
   @Bean("cib7embedded-user-task-modification-api")

--- a/engine-adapter/cib-seven-embedded-spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/springboot/Cib7EmbeddedAdapterProperties.kt
+++ b/engine-adapter/cib-seven-embedded-spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/springboot/Cib7EmbeddedAdapterProperties.kt
@@ -22,12 +22,29 @@ class Cib7EmbeddedAdapterProperties(
    * Configuration of user tasks.
    */
   @NestedConfigurationProperty
-  val userTasks: UserTasks
+  val userTasks: UserTasks,
+
+  /**
+   * Configuration of process deployment.
+   */
+  @NestedConfigurationProperty
+  val deployment: Deployment = Deployment()
 ) {
 
   companion object {
     const val DEFAULT_PREFIX = "dev.bpm-crafters.process-api.adapter.cib-seven-embedded"
   }
+
+  /**
+   * Configuration for process deployment.
+   */
+  data class Deployment(
+    /**
+     * If `true`, unchanged resources are not redeployed as new versions.
+     * Defaults to `false` to match the [CIB Seven] default
+     */
+    val deployOnlyOnChange: Boolean = false
+  )
 
   /**
    * Configuration for user task handling.


### PR DESCRIPTION
## What

Adds an opt-in **`deploy-only-on-change`** configuration flag to the CIB Seven embedded adapter. When enabled, the adapter activates the engine's duplicate filtering so unchanged BPMN/DMN resources are no longer redeployed as new versions on every deploy (e.g. on each application restart).

```yaml
dev:
  bpm-crafters:
    process-api:
      adapter:
        cib-seven-embedded:
          deployment:
            deploy-only-on-change: true   # default: false
```

## Why

Today every `deploy()` call creates a brand-new deployment and new process-definition versions even when the resources are byte-for-byte identical, bloating `ACT_RE_DEPLOYMENT` / `ACT_RE_PROCDEF` and the deployment cache. This brings CIB Seven (Camunda 7) in line with Camunda 8, which deduplicates by content automatically.

## How

- `DeploymentApiImpl` gets a `deployOnlyOnChange` flag; when `true` it calls `enableDuplicateFiltering(true)` on the `DeploymentBuilder` — only resources that actually changed are (re)deployed, unchanged resources keep their version, and nothing is deployed if nothing changed.
- Exposed as a single nested Spring property `deployment.deploy-only-on-change`, wired through the auto-configuration.
- Default is `false`, matching the [CIB Seven / Camunda 7 engine default](https://github.com/camunda/camunda-bpm-platform/blob/ee4826e5e76c2348a1510ef46a2f4ccd3b080e48/engine/src/main/java/org/camunda/bpm/engine/impl/repository/DeploymentBuilderImpl.java#L65) (duplicate filtering off) — so the change is **opt-in and non-breaking**.

## Tests

- Unit tests assert filtering is enabled (`enableDuplicateFiltering(true)`) only when the flag is set, and never otherwise.
- Full core + spring-boot-starter suites pass.

Closes #9
