### PR TITLE
feat: implement ChangeDatesModifyTaskCmd in user-task modification API

### DIFF
--- a/engine-adapter/cib-seven-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/task/modification/Cib7UserTaskModificationApiImpl.kt
+++ b/engine-adapter/cib-seven-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/task/modification/Cib7UserTaskModificationApiImpl.kt
@@ -3,6 +3,8 @@ package dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.task.modifica
 import dev.bpmcrafters.processengineapi.Empty
 import dev.bpmcrafters.processengineapi.task.ChangeAssignmentModifyTaskCmd
 import dev.bpmcrafters.processengineapi.task.ChangeAssignmentModifyTaskCmd.*
+import dev.bpmcrafters.processengineapi.task.ChangeDatesModifyTaskCmd
+import dev.bpmcrafters.processengineapi.task.ChangeDatesModifyTaskCmd.*
 import dev.bpmcrafters.processengineapi.task.ChangePayloadModifyTaskCmd
 import dev.bpmcrafters.processengineapi.task.ChangePayloadModifyTaskCmd.*
 import dev.bpmcrafters.processengineapi.task.CompositeModifyTaskCmd
@@ -10,6 +12,7 @@ import dev.bpmcrafters.processengineapi.task.ModifyTaskCmd
 import dev.bpmcrafters.processengineapi.task.UserTaskModificationApi
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.cibseven.bpm.engine.TaskService
+import java.util.Date
 import java.util.concurrent.CompletableFuture
 
 private val logger = KotlinLogging.logger {}
@@ -37,6 +40,7 @@ class Cib7UserTaskModificationApiImpl(
     when (cmd) {
       is ChangeAssignmentModifyTaskCmd -> changeAssignment(cmd)
       is ChangePayloadModifyTaskCmd -> changePayload(cmd)
+      is ChangeDatesModifyTaskCmd -> changeDates(cmd)
       else -> throw UnsupportedOperationException("Unsupported command ${cmd.javaClass.canonicalName}.")
     }
   }
@@ -64,5 +68,18 @@ class Cib7UserTaskModificationApiImpl(
       is ClearPayloadTaskCmd -> taskService.removeAllVariablesLocal(cmd.taskId)
       else -> throw UnsupportedOperationException("Unsupported command ${cmd.javaClass.canonicalName}.")
     }
+  }
+
+  private fun changeDates(cmd: ChangeDatesModifyTaskCmd) {
+    val task = taskService.createTaskQuery().taskId(cmd.taskId).singleResult()
+      ?: throw IllegalArgumentException("Task with id ${cmd.taskId} not found.")
+    when (cmd) {
+      is SetDueDateTaskCmd -> task.dueDate = Date.from(cmd.dueDate.toInstant())
+      is ClearDueDateTaskCmd -> task.dueDate = null
+      is SetFollowUpDateTaskCmd -> task.followUpDate = Date.from(cmd.followUpDate.toInstant())
+      is ClearFollowUpDateTaskCmd -> task.followUpDate = null
+      else -> throw UnsupportedOperationException("Unsupported command ${cmd.javaClass.canonicalName}.")
+    }
+    taskService.saveTask(task)
   }
 }

--- a/engine-adapter/cib-seven-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/task/modification/Cib7UserTaskModificationApiImplTest.kt
+++ b/engine-adapter/cib-seven-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/task/modification/Cib7UserTaskModificationApiImplTest.kt
@@ -1,11 +1,13 @@
 package dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.task.modification
 
 import dev.bpmcrafters.processengineapi.task.ChangeAssignmentModifyTaskCmd
+import dev.bpmcrafters.processengineapi.task.ChangeDatesModifyTaskCmd
 import dev.bpmcrafters.processengineapi.task.ChangePayloadModifyTaskCmd
 import dev.bpmcrafters.processengineapi.task.TaskModification
 import dev.bpmcrafters.processengineapi.task.UserTaskModificationApi
 import org.cibseven.bpm.engine.TaskService
 import org.cibseven.bpm.engine.impl.persistence.entity.IdentityLinkEntity
+import org.cibseven.bpm.engine.task.Task
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -14,6 +16,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
+import java.time.OffsetDateTime
 import java.util.*
 
 internal class Cib7UserTaskModificationApiImplTest {
@@ -242,6 +245,67 @@ internal class Cib7UserTaskModificationApiImplTest {
       ChangePayloadModifyTaskCmd.UpdatePayloadTaskCmd(taskId = taskId, payload = mapOf("key1" to "world"))
     ).get()
     verify(taskService).setVariablesLocal(taskId, mapOf("key1" to "world"))
+    verifyNoMoreInteractions(taskService)
+  }
+
+  private fun mockTaskQueryReturning(task: Task) {
+    val taskQuery = mock<org.cibseven.bpm.engine.task.TaskQuery>()
+    whenever(taskService.createTaskQuery()).thenReturn(taskQuery)
+    whenever(taskQuery.taskId(taskId)).thenReturn(taskQuery)
+    whenever(taskQuery.singleResult()).thenReturn(task)
+  }
+
+  @Test
+  fun `set due date`() {
+    val task: Task = mock()
+    mockTaskQueryReturning(task)
+    val dueDate = OffsetDateTime.now().plusDays(7)
+    api.update(
+      ChangeDatesModifyTaskCmd.SetDueDateTaskCmd(taskId = taskId, dueDate = dueDate)
+    ).get()
+    verify(taskService).createTaskQuery()
+    verify(task).dueDate = Date.from(dueDate.toInstant())
+    verify(taskService).saveTask(task)
+    verifyNoMoreInteractions(taskService)
+  }
+
+  @Test
+  fun `clear due date`() {
+    val task: Task = mock()
+    mockTaskQueryReturning(task)
+    api.update(
+      ChangeDatesModifyTaskCmd.ClearDueDateTaskCmd(taskId = taskId)
+    ).get()
+    verify(taskService).createTaskQuery()
+    verify(task).dueDate = null
+    verify(taskService).saveTask(task)
+    verifyNoMoreInteractions(taskService)
+  }
+
+  @Test
+  fun `set follow-up date`() {
+    val task: Task = mock()
+    mockTaskQueryReturning(task)
+    val followUpDate = OffsetDateTime.now().plusDays(3)
+    api.update(
+      ChangeDatesModifyTaskCmd.SetFollowUpDateTaskCmd(taskId = taskId, followUpDate = followUpDate)
+    ).get()
+    verify(taskService).createTaskQuery()
+    verify(task).followUpDate = Date.from(followUpDate.toInstant())
+    verify(taskService).saveTask(task)
+    verifyNoMoreInteractions(taskService)
+  }
+
+  @Test
+  fun `clear follow-up date`() {
+    val task: Task = mock()
+    mockTaskQueryReturning(task)
+    api.update(
+      ChangeDatesModifyTaskCmd.ClearFollowUpDateTaskCmd(taskId = taskId)
+    ).get()
+    verify(taskService).createTaskQuery()
+    verify(task).followUpDate = null
+    verify(taskService).saveTask(task)
     verifyNoMoreInteractions(taskService)
   }
 


### PR DESCRIPTION
## Summary

Implements **T1** of #63 — syncs the embedded CIB Seven adapter with its upstream brother [`process-engine-adapters-camunda-7`](https://github.com/bpm-crafters/process-engine-adapters-camunda-7).

`Cib7UserTaskModificationApiImpl` previously handled only Assignment / Payload / Composite commands and threw `UnsupportedOperationException` for date changes. It now handles `ChangeDatesModifyTaskCmd`:

- `SetDueDateTaskCmd` → set `task.dueDate`
- `ClearDueDateTaskCmd` → `task.dueDate = null`
- `SetFollowUpDateTaskCmd` → set `task.followUpDate`
- `ClearFollowUpDateTaskCmd` → `task.followUpDate = null`

Each branch queries the task (`createTaskQuery().taskId(...).singleResult()`, throwing `IllegalArgumentException` if not found) and persists via `taskService.saveTask(task)`.

Ports upstream [PR #183](https://github.com/bpm-crafters/process-engine-adapters-camunda-7/pull/183) (commit [`d267bb45`](https://github.com/bpm-crafters/process-engine-adapters-camunda-7/commit/d267bb45), released in [2026.04.2](https://github.com/bpm-crafters/process-engine-adapters-camunda-7/releases/tag/2026.04.2)).

## Notes

- **No API bump required** — `process-engine-api` is already at `1.6` and `ChangeDatesModifyTaskCmd` is part of it.
- Kept this fork's **synchronous, executor-less** style (the CIB7 modification API does not use `EngineCommandExecutor`, unlike upstream). Wiring the executor in is tracked separately as **T6** in #63 — root cause: the fork's executor sweep predated upstream wiring it into the modification/completion APIs.

## Tests

- 4 new unit tests in `Cib7UserTaskModificationApiImplTest`: due/follow-up **set + clear**.
- `Cib7UserTaskModificationApiImplTest`: 22/22 pass.
- Full repo `./mvnw -q verify`: **BUILD SUCCESS** (multi-module + JGiven/Testcontainers ITests).

Part of #63 (T1).
