### PR TITLE
feat: migrate to Spring Boot 4 via CIB seven 2.2.0 run4 starters

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,23 @@ respective [repository](https://github.com/bpm-crafters/process-engine-api-docs)
 
 ## Compatibility
 
-| Adapter Version                                                                                       | CIB Seven Version | API Version |
-|-------------------------------------------------------------------------------------------------------|-------------------|-------------|
-| [2026.04.1](https://github.com/bpm-crafters/process-engine-adapters-cib-seven/releases/tag/2026.04.1) | 2.1.0             | 1.5         |
-| [2026.02.1](https://github.com/bpm-crafters/process-engine-adapters-cib-seven/releases/tag/2026.02.1) | 2.1.0             | 1.5         |
-| [2025.12.1](https://github.com/bpm-crafters/process-engine-adapters-cib-seven/releases/tag/2025.12.1) | 2.1.0             | 1.4         |
+| Adapter Version                                                                                        | CIB Seven Version | API Version | Spring Boot |
+|--------------------------------------------------------------------------------------------------------|-------------------|-------------|-------------|
+| next release                                                                                            | 2.2.0             | 1.6         | 4.0         |
+| [2026.04.1](https://github.com/bpm-crafters/process-engine-adapters-cib-seven/releases/tag/2026.04.1)  | 2.1.0             | 1.5         | 3.5         |
+| [2026.02.1](https://github.com/bpm-crafters/process-engine-adapters-cib-seven/releases/tag/2026.02.1)  | 2.1.0             | 1.5         | 3.5         |
+| [2025.12.1](https://github.com/bpm-crafters/process-engine-adapters-cib-seven/releases/tag/2025.12.1)  | 2.1.0             | 1.4         | 3.5         |
+
+### Spring Boot 4
+
+The adapter starter requires Spring Boot 4. The CIB seven engine starters are `provided`
+dependencies of the adapter, so your application brings the `-4` variants (e.g.
+`cibseven-bpm-spring-boot-starter-4`, `cibseven-bpm-spring-boot-starter-webapp-4`). Note that since
+the Spring Boot 4 module split, the DataSource / transaction manager auto-configurations live in
+`spring-boot-jdbc`, which the CIB seven starter-4 does not bring transitively — add
+`spring-boot-starter-jdbc` (or `-data-jpa`) to your application.
+
+If you are still on Spring Boot 3.5, stay on adapter version `2026.04.1`.
 
 
 

--- a/engine-adapter/cib-seven-embedded-core/pom.xml
+++ b/engine-adapter/cib-seven-embedded-core/pom.xml
@@ -12,10 +12,6 @@
   <artifactId>process-engine-adapter-cib-seven-embedded-core</artifactId>
   <name>Adapter: CIB7 Embedded Core</name>
 
-  <properties>
-    <cibseven.version>2.1.0</cibseven.version>
-  </properties>
-
   <dependencyManagement>
     <dependencies>
       <!-- https://central.sonatype.com/artifact/org.cibseven.bpm/cibseven-bom -->
@@ -79,7 +75,7 @@
     </dependency>
     <dependency>
       <groupId>org.cibseven.bpm.springboot</groupId>
-      <artifactId>cibseven-bpm-spring-boot-starter-test</artifactId>
+      <artifactId>cibseven-bpm-spring-boot-starter-test-4</artifactId>
       <version>${cibseven.version}</version>
       <scope>test</scope>
     </dependency>

--- a/engine-adapter/cib-seven-embedded-spring-boot-starter/pom.xml
+++ b/engine-adapter/cib-seven-embedded-spring-boot-starter/pom.xml
@@ -18,7 +18,7 @@
       <dependency>
         <groupId>org.cibseven.bpm</groupId>
         <artifactId>cibseven-bom</artifactId>
-        <version>2.1.0</version>
+        <version>${cibseven.version}</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -51,8 +51,8 @@
     </dependency>
     <dependency>
       <groupId>org.cibseven.bpm.springboot</groupId>
-      <artifactId>cibseven-bpm-spring-boot-starter</artifactId>
-      <version>2.1.0</version>
+      <artifactId>cibseven-bpm-spring-boot-starter-4</artifactId>
+      <version>${cibseven.version}</version>
       <scope>provided</scope>
     </dependency>
 
@@ -64,13 +64,20 @@
     </dependency>
     <dependency>
       <groupId>org.cibseven.bpm.springboot</groupId>
-      <artifactId>cibseven-bpm-spring-boot-starter-test</artifactId>
-      <version>2.1.0</version>
+      <artifactId>cibseven-bpm-spring-boot-starter-test-4</artifactId>
+      <version>${cibseven.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- Since the Spring Boot 4 module split, the DataSource / transaction manager auto-configurations
+         live in spring-boot-jdbc, which the cibseven starter-4 does not bring transitively anymore -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-jdbc</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/engine-adapter/cib-seven-embedded-spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/springboot/schedule/Cib7EmbeddedSchedulingAutoConfiguration.kt
+++ b/engine-adapter/cib-seven-embedded-spring-boot-starter/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/springboot/schedule/Cib7EmbeddedSchedulingAutoConfiguration.kt
@@ -21,9 +21,9 @@ import org.cibseven.bpm.engine.TaskService
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.AutoConfigureAfter
 import org.springframework.boot.autoconfigure.condition.ConditionalOnThreading
-import org.springframework.boot.autoconfigure.thread.Threading
 import org.springframework.boot.task.SimpleAsyncTaskSchedulerBuilder
 import org.springframework.boot.task.ThreadPoolTaskSchedulerBuilder
+import org.springframework.boot.thread.Threading
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Conditional
 import org.springframework.context.annotation.Configuration
@@ -56,7 +56,7 @@ class Cib7EmbeddedSchedulingAutoConfiguration {
   fun taskScheduler(): TaskScheduler {
     val threadPoolTaskScheduler = ThreadPoolTaskScheduler()
     threadPoolTaskScheduler.poolSize = 2 // we have two schedulers, one for user tasks one for service tasks
-    threadPoolTaskScheduler.threadNamePrefix = "CIB-SEVEN-EMBEDDED-SCHEDULER-"
+    threadPoolTaskScheduler.setThreadNamePrefix("CIB-SEVEN-EMBEDDED-SCHEDULER-")
     return threadPoolTaskScheduler
   }
 

--- a/examples/java-cib-seven-embedded/pom.xml
+++ b/examples/java-cib-seven-embedded/pom.xml
@@ -12,10 +12,6 @@
   <artifactId>process-engine-api-example-java-cib-seven-embedded</artifactId>
   <name>Example: Java CIB-seven Embedded</name>
 
-  <properties>
-    <cibseven.version>2.1.0</cibseven.version>
-  </properties>
-
   <dependencyManagement>
     <dependencies>
       <!-- https://central.sonatype.com/artifact/org.cibseven.bpm/cibseven-bom -->
@@ -42,18 +38,22 @@
 
     <dependency>
       <groupId>org.cibseven.bpm.springboot</groupId>
-      <artifactId>cibseven-bpm-spring-boot-starter-webapp</artifactId>
+      <artifactId>cibseven-bpm-spring-boot-starter-webapp-4</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.holunda</groupId>
-      <artifactId>camunda-platform-7-autologin</artifactId>
-      <version>2026.04.2</version>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-jdbc</artifactId>
     </dependency>
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.cibseven.bpm</groupId>
       <artifactId>cibseven-bpm-junit5</artifactId>

--- a/examples/java-cib-seven-embedded/src/main/resources/application.yml
+++ b/examples/java-cib-seven-embedded/src/main/resources/application.yml
@@ -28,17 +28,22 @@ dev:
             delivery-strategy: embedded_scheduled
             execute-initial-pull-on-startup: true
             schedule-delivery-fixed-rate-in-seconds: 10
+
+# DO NOT reuse this example secret in production.
+cibseven:
+  webclient:
+    authentication:
+      jwtSecret: "al/gEH0veB+E9mAezx1L10291Ao2uJIJVNaWP4pIe2GfsUgMs15KLWiHONt7Y3vQfXVkv9kK5APdpMmzcq9+eIV61RyQZ/Q+1RdpL6XkQXH6cSlY4CrqrSd72R0I8tcF0nPQSnl7SHCGxiCfCNJr8h+dn7NYfIBgXPu9F3cw"
+
 camunda:
   bpm:
     webapp:
       index-redirect-enabled: false
     admin-user:
       id: admin
+      password: admin
     filter:
       create: All
-    login:
-      enabled: true
-      user-id: admin
     auto-deployment-enabled: false
     default-serialization-format: application/json
 

--- a/examples/java-cib-seven-embedded/src/test/java/dev/bpmcrafters/example/cibseven/ApplicationStartsITest.java
+++ b/examples/java-cib-seven-embedded/src/test/java/dev/bpmcrafters/example/cibseven/ApplicationStartsITest.java
@@ -1,0 +1,29 @@
+package dev.bpmcrafters.example.cibseven;
+
+import dev.bpmcrafters.processengineapi.process.StartProcessApi;
+import dev.bpmcrafters.processengineapi.task.TaskSubscriptionApi;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Smoke test booting the full Spring Boot application including the embedded CIB seven engine
+ * and the adapter auto-configuration.
+ */
+@SpringBootTest
+class ApplicationStartsITest {
+
+  @Autowired
+  private StartProcessApi startProcessApi;
+
+  @Autowired
+  private TaskSubscriptionApi taskSubscriptionApi;
+
+  @Test
+  void adapter_apis_are_auto_configured() {
+    assertThat(startProcessApi).isNotNull();
+    assertThat(taskSubscriptionApi).isNotNull();
+  }
+}

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -44,7 +44,7 @@
       <dependency>
         <groupId>org.springdoc</groupId>
         <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-        <version>2.8.17</version>
+        <version>3.0.3</version>
       </dependency>
 
       <!-- Adapter dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>dev.bpm-crafters.maven.parent</groupId>
     <artifactId>maven-parent</artifactId>
-    <version>2026.02.1</version>
+    <version>2026.06.1</version>
     <relativePath/>
   </parent>
 
@@ -19,9 +19,10 @@
 
   <properties>
     <!-- COMMON GLOBAL -->
-    <spring-boot.version>3.5.15</spring-boot.version>
+    <spring-boot.version>4.0.7</spring-boot.version>
     <process-engine-api.version>1.6</process-engine-api.version>
-    <cibseven.version>2.1.0</cibseven.version>
+    <cibseven.version>2.2.0</cibseven.version>
+    <kotlin-logging.version>7.0.13</kotlin-logging.version>
     <!-- TEST -->
     <mockito.version>6.3.0</mockito.version>
     <assertj.version>3.27.7</assertj.version>


### PR DESCRIPTION
## Summary

Migrates the adapter to **Spring Boot 4.0.7** and the **CIB seven 2.2.0** `-4` starter artifacts. The next release supports **Spring Boot 4 only** — Spring Boot 3.5 support is dropped (consumers staying on 3.5 should remain on adapter `2026.04.1`).

Closes #62 (and supersedes #59, which only bumped cibseven to 2.2.0 while staying on Spring Boot 3).

## Changes

- Bump `spring-boot.version` to `4.0.7` and `cibseven.version` to `2.2.0` (root POM, hardcoded versions replaced by the property)
- Switch the starter to `cibseven-bpm-spring-boot-starter-4` (provided) and `cibseven-bpm-spring-boot-starter-test-4` (test)
- Add `spring-boot-starter-jdbc` where needed: since the Spring Boot 4 module split, the DataSource / transaction manager auto-configurations live in `spring-boot-jdbc`, which the cibseven starter-4 no longer brings transitively
- Keep the idiomatic `@ConditionalOnThreading(VIRTUAL/PLATFORM)` task scheduler beans in `Cib7EmbeddedSchedulingAutoConfiguration`, importing `Threading` from its Spring Boot 4 package (`org.springframework.boot.thread`)
- Update the SB4 example (`examples/java-cib-seven-embedded`) to the `-4` cibseven starters, with a `@SpringBootTest` smoke test that boots the full application (embedded engine + webapp + adapter auto-configuration)
- Update the README compatibility table (new Spring Boot column) and document the Spring Boot 4 starter setup for consumers

## Fixed along the way

- **Removed `io.holunda:camunda-platform-7-autologin` from the examples.** The new smoke tests revealed it can never boot with the cibseven stack (it requires `org.camunda.bpm.spring.boot.starter.*` classes that do not exist in any cibseven artifact) — pre-existing breakage that CI never caught because nothing booted the app. Replaced by a configured `admin-user`.
- **Configured the cibseven webclient JWT secret** (`cibseven.webclient.authentication.jwtSecret`, required since 2.2.0; dev-only secret) in the example config.

## Watch items

- `cibseven-mockito` has no 2.2.0 release yet — 2.1.0 (test scope) works against engine 2.2.0
- `io.toolisticon.spring:spring-boot-conditions` 1.0.1 predates Spring Boot 4 but works fine (verified by the starter integration tests)

## Verification

- `./mvnw clean verify` — full reactor green (core tests, starter integration tests, example suite)
- SB4 example boots the complete app on Boot 4.0.7 (webapp-4 + adapter auto-configuration), Java 25
