### PR TITLE
chore(ci): pin github actions to exact version tags

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -35,14 +35,14 @@ jobs:
     steps:
       # Checkout the code
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.0
 
       - name: Expose branch name
         run: echo ${{ github.ref }}
 
       # Setup JDK and Maven
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.3.0
         with:
           java-version-file: .java-version
           distribution: 'zulu'

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -14,11 +14,11 @@ jobs:
     name: Build and run tests
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.0
 
       # Setup JDK and .m2/settings.xml
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.3.0
         with:
           java-version-file: .java-version
           distribution: 'zulu'

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@master
+      uses: actions/checkout@v7.0.0
     - name: Create Release Notes Markdown
       uses: docker://ghcr.io/rohwerj/release-notes-generator-action:v1.0.0
       env:
@@ -27,7 +27,7 @@ jobs:
         echo "VERSION=$VERSION" >> $GITHUB_ENV
     - name: Create a Draft Release Notes on GitHub
       id: create_release
-      uses: actions/create-release@v1
+      uses: actions/create-release@v1.1.4
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
       with:


### PR DESCRIPTION
## What

Pins every external GitHub Action `uses:` reference in the workflow files to an **exact version tag** (`@vX.Y.Z`) instead of a moving ref (major-only `@vX`, or a branch like `@master`).

## Why

Moving refs silently advance: a major-only tag (`@v7`) or a branch (`@master`) can change under us without any change to this repo, which makes CI non-reproducible and is a supply-chain risk. Pinning to a full semver tag protects against **major-version drift** — a build runs the exact code we reviewed.

Note: `@master` on `actions/checkout` in `release-notes.yml` was a **branch ref** — the most volatile kind — now pinned to a concrete release.

## Mapping

| Action | Before | After |
|---|---|---|
| `actions/checkout` (development.yml, master.yml) | `@v7` | `@v7.0.0` |
| `actions/checkout` (release-notes.yml) | `@master` | `@v7.0.0` |
| `actions/setup-java` | `@v5` | `@v5.3.0` |
| `actions/create-release` | `@v1` | `@v1.1.4` |

Left untouched (already pinned / not a moving repo ref):
- `codecov/codecov-action@v7.0.0` — already a full semver tag
- `docker://ghcr.io/rohwerj/release-notes-generator-action:v1.0.0` — Docker image already at exact version
- Local reusable references (`./...`) — none present

All new tags stay within the same major as before, so no breaking updates are introduced.

## Next step

Tag-pinning guards against major drift; **full-SHA pinning** (`@<40-char-sha>`) would be the next stronger level (immune to tag re-pointing entirely).