### PR TITLE
feat: start process by message at element

### DIFF
--- a/engine-adapter/adapter-testing/src/main/kotlin/dev/bpmcrafters/processengineapi/test/BaseGivenWhenStage.kt
+++ b/engine-adapter/adapter-testing/src/main/kotlin/dev/bpmcrafters/processengineapi/test/BaseGivenWhenStage.kt
@@ -5,6 +5,7 @@ import com.tngtech.jgiven.annotation.ExpectedScenarioState
 import com.tngtech.jgiven.annotation.ProvidedScenarioState
 import dev.bpmcrafters.processengineapi.process.StartProcessByDefinitionAtElementCmd
 import dev.bpmcrafters.processengineapi.process.StartProcessByDefinitionCmd
+import dev.bpmcrafters.processengineapi.process.StartProcessByMessageAtElementCmd
 import dev.bpmcrafters.processengineapi.process.StartProcessByMessageCmd
 import dev.bpmcrafters.processengineapi.task.*
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -72,6 +73,16 @@ class BaseGivenWhenStage : Stage<BaseGivenWhenStage>() {
     instanceId = processTestHelper.getStartProcessApi().startProcess(
       StartProcessByDefinitionAtElementCmd(
         definitionKey = definitionKey,
+        elementId = elementId,
+        payloadSupplier = { emptyMap() },
+      )
+    ).get().instanceId
+  }
+
+  fun `start process by message at element`(messageName: String, elementId: String) = step {
+    instanceId = processTestHelper.getStartProcessApi().startProcess(
+      StartProcessByMessageAtElementCmd(
+        messageName = messageName,
         elementId = elementId,
         payloadSupplier = { emptyMap() },
       )

--- a/engine-adapter/adapter-testing/src/main/kotlin/dev/bpmcrafters/processengineapi/test/BaseThenStage.kt
+++ b/engine-adapter/adapter-testing/src/main/kotlin/dev/bpmcrafters/processengineapi/test/BaseThenStage.kt
@@ -27,6 +27,14 @@ class BaseThenStage : Stage<BaseThenStage>() {
     assertThat(process).isNotNull()
   }
 
+  fun `we should have an active token in element`(elementId: String) = step {
+    await().untilAsserted {
+      assertThat(processTestHelper.getActiveElements(instanceId))
+        .describedAs("Process %s has no active token in element %s", instanceId, elementId)
+        .contains(elementId)
+    }
+  }
+
   fun `we should get notified about a new user task with pull strategy`() = step {
     processTestHelper.triggerPullingUserTaskDeliveryManually()
 

--- a/engine-adapter/adapter-testing/src/main/kotlin/dev/bpmcrafters/processengineapi/test/ProcessTestHelper.kt
+++ b/engine-adapter/adapter-testing/src/main/kotlin/dev/bpmcrafters/processengineapi/test/ProcessTestHelper.kt
@@ -24,6 +24,8 @@ interface ProcessTestHelper {
 
   fun getProcessInformation(instanceId: String): ProcessInformation
 
+  fun getActiveElements(instanceId: String): Collection<String>
+
   fun clearAllSubscriptions()
 
 }

--- a/engine-adapter/cib-seven-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/process/StartProcessApiImpl.kt
+++ b/engine-adapter/cib-seven-embedded-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/process/StartProcessApiImpl.kt
@@ -9,6 +9,7 @@ import dev.bpmcrafters.processengineapi.process.ProcessInformation
 import dev.bpmcrafters.processengineapi.process.StartProcessApi
 import dev.bpmcrafters.processengineapi.process.StartProcessByDefinitionAtElementCmd
 import dev.bpmcrafters.processengineapi.process.StartProcessByDefinitionCmd
+import dev.bpmcrafters.processengineapi.process.StartProcessByMessageAtElementCmd
 import dev.bpmcrafters.processengineapi.process.StartProcessByMessageCmd
 import dev.bpmcrafters.processengineapi.process.StartProcessCommand
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -81,6 +82,23 @@ class StartProcessApiImpl(
           logger.debug { "PROCESS-ENGINE-CIB7-EMBEDDED-006: starting a new process instance by definition ${cmd.definitionKey} at element ${cmd.elementId}" }
           val startProcessCommand = StartProcessByDefinitionCmd(
             definitionKey = cmd.definitionKey,
+            payloadSupplier = cmd.payloadSupplier,
+            restrictions = cmd.restrictions,
+          )
+          val instance = this.startProcess(startProcessCommand).get()
+          val processDefinitionId = instance.meta[CommonRestrictions.PROCESS_DEFINITION_KEY] as String
+          runtimeService.createModification(processDefinitionId)
+            .processInstanceIds(instance.instanceId)
+            .startBeforeActivity(cmd.elementId)
+            .execute()
+          instance
+        }
+
+      is StartProcessByMessageAtElementCmd ->
+        commandExecutor.execute {
+          logger.debug { "PROCESS-ENGINE-CIB7-EMBEDDED-015: starting a new process instance by message ${cmd.messageName} at element ${cmd.elementId}" }
+          val startProcessCommand = StartProcessByMessageCmd(
+            messageName = cmd.messageName,
             payloadSupplier = cmd.payloadSupplier,
             restrictions = cmd.restrictions,
           )

--- a/engine-adapter/cib-seven-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/process/Cib7EmbeddedProcessTestHelper.kt
+++ b/engine-adapter/cib-seven-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/process/Cib7EmbeddedProcessTestHelper.kt
@@ -83,6 +83,9 @@ class Cib7EmbeddedProcessTestHelper(
       .singleResult()
       .toProcessInformation()
 
+  override fun getActiveElements(instanceId: String): Collection<String> =
+    processEngine.runtimeService.getActiveActivityIds(instanceId)
+
   override fun clearAllSubscriptions() = subscriptionRepository.deleteAllTaskSubscriptions()
 
 

--- a/engine-adapter/cib-seven-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/process/StartProcessApiImplTest.kt
+++ b/engine-adapter/cib-seven-embedded-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/process/StartProcessApiImplTest.kt
@@ -4,6 +4,7 @@ import dev.bpmcrafters.processengineapi.CommonRestrictions
 import dev.bpmcrafters.processengineapi.adapter.cibseven.embedded.shared.EngineCommandExecutor
 import dev.bpmcrafters.processengineapi.process.StartProcessByDefinitionAtElementCmd
 import dev.bpmcrafters.processengineapi.process.StartProcessByDefinitionCmd
+import dev.bpmcrafters.processengineapi.process.StartProcessByMessageAtElementCmd
 import dev.bpmcrafters.processengineapi.process.StartProcessByMessageCmd
 import org.cibseven.bpm.engine.RepositoryService
 import org.cibseven.bpm.engine.RuntimeService
@@ -156,9 +157,7 @@ class StartProcessApiImplTest {
     val businessKey = "myBusinessKey"
     val modificationBuilder = modifyProcessInstanceBuilderMock()
     val processDefinitionId = "simple-process:1:123"
-    val processInstance = ProcessInstanceFake.builder().id("instance-123")
-      .processDefinitionId(processDefinitionId)
-      .build()
+    val processInstance = processInstanceMock(processDefinitionId)
 
     whenever(runtimeService.startProcessInstanceByKey(anyString(), anyOrNull(), anyMap())).thenReturn(processInstance)
     whenever(runtimeService.createModification(processDefinitionId)).thenReturn(modificationBuilder)
@@ -179,14 +178,52 @@ class StartProcessApiImplTest {
     verify(modificationBuilder).execute()
   }
 
-  private fun messageCorrelationMock(): MessageCorrelationBuilder {
+  @Test
+  fun `should start process via message at element without payload`() {
+
+    // given
+    val businessKey = "myBusinessKey"
+    val modificationBuilder = modifyProcessInstanceBuilderMock()
+    val processDefinitionId = "simple-process:1:123"
+    val processInstance = processInstanceMock(processDefinitionId)
+    val correlationBuilder = messageCorrelationMock(processInstance)
+
+    whenever(runtimeService.createMessageCorrelation(any())).thenReturn(correlationBuilder)
+    whenever(runtimeService.createModification(processDefinitionId)).thenReturn(modificationBuilder)
+
+    val cmd = StartProcessByMessageAtElementCmd(
+      messageName = "startMessage",
+      elementId = "user-perform-task",
+      payloadSupplier = { mapOf(CommonRestrictions.BUSINESS_KEY to businessKey) }
+    )
+
+    // when
+    startProcessApi.startProcess(cmd).get()
+
+    // then
+    verify(runtimeService).createMessageCorrelation("startMessage")
+    verify(correlationBuilder).processInstanceBusinessKey(businessKey)
+    verify(runtimeService).createModification(processDefinitionId)
+    verify(modificationBuilder).startBeforeActivity("user-perform-task")
+    verify(modificationBuilder).execute()
+  }
+
+  private fun messageCorrelationMock(
+    processInstance: ProcessInstance = ProcessInstanceFake.builder().id("someId").build()
+  ): MessageCorrelationBuilder {
     val builder: MessageCorrelationBuilder = mock()
     lenient().whenever(builder.processInstanceBusinessKey(any())).thenReturn(builder)
     whenever(builder.setVariables(anyMap())).thenReturn(builder)
-    whenever(builder.correlateStartMessage()).thenReturn(ProcessInstanceFake.builder().id("someId").build())
+    whenever(builder.correlateStartMessage()).thenReturn(processInstance)
 
     return builder
   }
+
+  private fun processInstanceMock(processDefinitionId: String): ProcessInstance =
+    ProcessInstanceFake.builder()
+      .id("instance-123")
+      .processDefinitionId(processDefinitionId)
+      .build()
 
   private fun modifyProcessInstanceBuilderMock(): ModificationBuilder {
     val builder = mock<ModificationBuilder>()

--- a/engine-adapter/cib-seven-embedded-spring-boot-starter/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/springboot/Cib7EmbeddedSpringProcessTestHelper.kt
+++ b/engine-adapter/cib-seven-embedded-spring-boot-starter/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/springboot/Cib7EmbeddedSpringProcessTestHelper.kt
@@ -43,6 +43,9 @@ class Cib7EmbeddedSpringProcessTestHelper(
       .singleResult()
       .toProcessInformation()
 
+  override fun getActiveElements(instanceId: String): Collection<String> =
+    runtimeService.getActiveActivityIds(instanceId)
+
   override fun clearAllSubscriptions() = (subscriptionRepository as InMemSubscriptionRepository).deleteAllTaskSubscriptions()
 
 }

--- a/engine-adapter/cib-seven-embedded-spring-boot-starter/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/springboot/Cib7EmbeddedSpringStartProcessApiITest.kt
+++ b/engine-adapter/cib-seven-embedded-spring-boot-starter/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/springboot/Cib7EmbeddedSpringStartProcessApiITest.kt
@@ -54,4 +54,13 @@ class Cib7EmbeddedSpringStartProcessApiITest(
     THEN
       .`we should have a running process`()
   }
+
+  @Test
+  fun `should start process at element by message`() {
+    WHEN
+      .`start process by message at element`(START_MESSAGE, "service-do-action2")
+
+    THEN
+      .`we should have a running process`()
+  }
 }

--- a/engine-adapter/cib-seven-embedded-spring-boot-starter/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/springboot/Cib7EmbeddedSpringStartProcessApiITest.kt
+++ b/engine-adapter/cib-seven-embedded-spring-boot-starter/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/cibseven/embedded/springboot/Cib7EmbeddedSpringStartProcessApiITest.kt
@@ -53,6 +53,7 @@ class Cib7EmbeddedSpringStartProcessApiITest(
 
     THEN
       .`we should have a running process`()
+      .`we should have an active token in element`("service-do-action2")
   }
 
   @Test
@@ -62,5 +63,6 @@ class Cib7EmbeddedSpringStartProcessApiITest(
 
     THEN
       .`we should have a running process`()
+      .`we should have an active token in element`("service-do-action2")
   }
 }


### PR DESCRIPTION
## What

Implements `StartProcessByMessageAtElementCmd` in `cib-seven-embedded`, analogous to the existing `StartProcessByDefinitionAtElementCmd` — but it starts a process at a specific element via a **message name** instead of a definition key.

This enables starting at a given element for processes that have **no plain (none) start event** and are entered only through one or multiple **message start events** — the use case in #73.

## How

`StartProcessApiImpl` gains a new `is StartProcessByMessageAtElementCmd` branch that uses the same start-then-modify pattern as its definition-based sibling:

1. Correlate the start message (delegating to the existing `StartProcessByMessageCmd` path, so tenant restrictions and business key are reused).
2. `runtimeService.createModification(processDefinitionId).processInstanceIds(...).startBeforeActivity(elementId).execute()`.

No dispatch changes elsewhere — `StartProcessApi.startProcess(...)` accepts the command polymorphically.

## Tests (mirroring the definition-based variant)

- **Unit** (`StartProcessApiImplTest`): `should start process via message at element without payload` — verifies message correlation + modification. Extracted a shared `processInstanceMock(...)` helper alongside `messageCorrelationMock(...)`.
- **Integration** (`Cib7EmbeddedSpringStartProcessApiITest`): `should start process at element by message` — starts via the `startMessage` start event at `service-do-action2`.
- **Adapter-testing**: new `start process by message at element` JGiven stage.

## Dependency / CI note

Requires **process-engine-api 1.7**, where `StartProcessByMessageAtElementCmd` was added (bpm-crafters/process-engine-api#293, refs #292). `process-engine-api.version` is bumped `1.6 → 1.7`.

⚠️ **1.7 is not yet released to Maven Central** (latest is 1.6), so CI here will stay red until it is published. The adapter code is fully verified against the API-identical `1.7-SNAPSHOT` (all unit + integration tests pass); only the published dependency is missing. Once process-engine-api 1.7 lands on Central, this branch goes green with no further changes.

Closes #73