### PR TITLE
ci: periodically mirror Camunda 7 issues into this repo

### DIFF
--- a/.github/workflows/sync-c7-issues.yml
+++ b/.github/workflows/sync-c7-issues.yml
@@ -1,0 +1,73 @@
+name: Sync Camunda 7 Issues
+
+# The CIB Seven adapter is largely based on the Camunda 7 adapter, so bugs and
+# enhancements reported there often apply here as well. Issues are maintained
+# primarily on the Camunda 7 repo, so this workflow periodically mirrors the
+# relevant open issues into this repo for triage. Both repos are public, so the
+# built-in GITHUB_TOKEN can read the source and create issues here — no PAT needed.
+
+on:
+  schedule:
+    - cron: '11 6 * * *'      # daily 06:11 UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+env:
+  SOURCE_REPO: bpm-crafters/process-engine-adapters-camunda-7
+  SYNC_LABELS: '["Type: bug","Type: enhancement"]'   # OR-matched
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mirror relevant open Camunda 7 issues into this repo
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Ensure the marker label exists (idempotent)
+          gh label create "Source: c7" --repo "$TARGET_REPO" \
+            --color "0e8a16" --description "Mirrored from the Camunda 7 adapter" --force || true
+
+          # Titles already present in this repo — used for deduplication
+          existing=$(gh issue list --repo "$TARGET_REPO" --state all --limit 500 --json title \
+                     | jq -r '.[].title')
+
+          # Open source issues carrying any of the relevant labels (one compact JSON object per line)
+          gh issue list --repo "$SOURCE_REPO" --state open --limit 200 \
+            --json number,title,body,labels,url \
+          | jq -c --argjson want "$SYNC_LABELS" '
+              .[] | select([.labels[].name] as $has | any($want[]; . as $w | $has | index($w)))' \
+          | while IFS= read -r row; do
+              num=$(jq -r '.number' <<<"$row")
+              title=$(jq -r '.title' <<<"$row")
+              body=$(jq -r '.body // ""' <<<"$row")
+              url=$(jq -r '.url' <<<"$row")
+
+              # Dedup by the stable "[c7#<num>]" title prefix.
+              # The closing bracket in the pattern prevents 12 from matching 123.
+              if grep -qF "[c7#$num]" <<<"$existing"; then
+                echo "skip c7#$num (already mirrored)"
+                continue
+              fi
+
+              # Carry over only the source "Type:" labels that also exist here
+              label_args=()
+              while IFS= read -r l; do
+                [ -n "$l" ] && label_args+=(--label "$l")
+              done < <(jq -r --argjson want "$SYNC_LABELS" \
+                         '.labels[].name | select(. as $n | $want | index($n))' <<<"$row")
+
+              new_body=$(printf '> Synced from %s\n\n%s\n\n<!-- synced-from: c7#%s -->' \
+                         "$url" "$body" "$num")
+
+              gh issue create --repo "$TARGET_REPO" \
+                --title "[c7#$num] $title" \
+                --body "$new_body" \
+                --label "Source: c7" "${label_args[@]}" </dev/null
+              echo "created mirror for c7#$num"
+            done

--- a/.github/workflows/sync-c7-issues.yml
+++ b/.github/workflows/sync-c7-issues.yml
@@ -1,10 +1,10 @@
 name: Sync Camunda 7 Issues
 
-# The CIB Seven adapter is largely based on the Camunda 7 adapter, so bugs and
-# enhancements reported there often apply here as well. Issues are maintained
-# primarily on the Camunda 7 repo, so this workflow periodically mirrors the
-# relevant open issues into this repo for triage. Both repos are public, so the
-# built-in GITHUB_TOKEN can read the source and create issues here — no PAT needed.
+# The CIB Seven adapter is largely based on the Camunda 7 adapter, so issues
+# reported there often apply here as well. Issues are maintained primarily on
+# the Camunda 7 repo, so this workflow periodically mirrors all open issues into
+# this repo for triage. Both repos are public, so the built-in GITHUB_TOKEN can
+# read the source and create issues here — no PAT needed.
 
 on:
   schedule:
@@ -16,13 +16,12 @@ permissions:
 
 env:
   SOURCE_REPO: bpm-crafters/process-engine-adapters-camunda-7
-  SYNC_LABELS: '["Type: bug","Type: enhancement"]'   # OR-matched
 
 jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - name: Mirror relevant open Camunda 7 issues into this repo
+      - name: Mirror open Camunda 7 issues into this repo
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TARGET_REPO: ${{ github.repository }}
@@ -33,15 +32,18 @@ jobs:
           gh label create "Source: c7" --repo "$TARGET_REPO" \
             --color "0e8a16" --description "Mirrored from the Camunda 7 adapter" --force || true
 
+          # Labels that exist in this repo — only these are carried over from the source
+          target_labels=$(gh label list --repo "$TARGET_REPO" --limit 200 --json name \
+                          | jq -r '.[].name')
+
           # Titles already present in this repo — used for deduplication
           existing=$(gh issue list --repo "$TARGET_REPO" --state all --limit 500 --json title \
                      | jq -r '.[].title')
 
-          # Open source issues carrying any of the relevant labels (one compact JSON object per line)
+          # All open source issues (gh issue list already excludes pull requests)
           gh issue list --repo "$SOURCE_REPO" --state open --limit 200 \
             --json number,title,body,labels,url \
-          | jq -c --argjson want "$SYNC_LABELS" '
-              .[] | select([.labels[].name] as $has | any($want[]; . as $w | $has | index($w)))' \
+          | jq -c '.[]' \
           | while IFS= read -r row; do
               num=$(jq -r '.number' <<<"$row")
               title=$(jq -r '.title' <<<"$row")
@@ -55,12 +57,13 @@ jobs:
                 continue
               fi
 
-              # Carry over only the source "Type:" labels that also exist here
-              label_args=()
+              # Always tag the mirror, plus carry over each source label that also exists here
+              label_args=(--label "Source: c7")
               while IFS= read -r l; do
-                [ -n "$l" ] && label_args+=(--label "$l")
-              done < <(jq -r --argjson want "$SYNC_LABELS" \
-                         '.labels[].name | select(. as $n | $want | index($n))' <<<"$row")
+                if [ -n "$l" ] && grep -qxF "$l" <<<"$target_labels"; then
+                  label_args+=(--label "$l")
+                fi
+              done < <(jq -r '.labels[].name' <<<"$row")
 
               new_body=$(printf '> Synced from %s\n\n%s\n\n<!-- synced-from: c7#%s -->' \
                          "$url" "$body" "$num")
@@ -68,6 +71,6 @@ jobs:
               gh issue create --repo "$TARGET_REPO" \
                 --title "[c7#$num] $title" \
                 --body "$new_body" \
-                --label "Source: c7" "${label_args[@]}" </dev/null
+                "${label_args[@]}" </dev/null
               echo "created mirror for c7#$num"
             done


### PR DESCRIPTION
## Why

The CIB Seven adapter is largely based on the [Camunda 7 adapter](https://github.com/bpm-crafters/process-engine-adapters-camunda-7). Bugs therefore often exist in both, and enhancements are frequently worth doing in both — but issues are maintained **primarily on the Camunda 7 repo**, so relevant work never surfaces here.

This adds a **scheduled GitHub Action** that mirrors open Camunda 7 issues into this repo, so they can be triaged and (if applicable) fixed here too.

## What it does

`.github/workflows/sync-c7-issues.yml`:

- **Trigger:** daily cron (`11 6 * * *`) + manual `workflow_dispatch`.
- **Scope:** **all** open Camunda 7 issues (pull requests are excluded automatically).
- **For each new one:** creates an issue here titled `[c7#<n>] <title>`, with a back-link header (`> Synced from <url>`), the original body, a hidden `<!-- synced-from: c7#<n> -->` marker, the `Source: c7` label (auto-created), and any source label that also exists in this repo (c7-only labels such as `Type: breaking` are dropped so creation never fails).
- **Deduplication:** by the stable `[c7#<n>]` title prefix, so reruns never create duplicates.

## Auth

Both repos are **public**, so the run uses only the built-in `GITHUB_TOKEN` (reads the public source, writes issues here). **No PAT or GitHub App secret is required** — the sync is one-directional (c7 → cib-seven).

## Notes / possible follow-ups

- Independent lifecycle: mirrors are **not** auto-closed when the source closes (a fix here is separate work).
- Optional toggles: add `--assignee emaarco`, narrow the scope back to specific labels, or add source→mirror state sync later.

## How to test

1. Merge to `develop` (scheduled workflows only run from the default branch).
2. Run the workflow manually from the **Actions** tab (`workflow_dispatch`).
3. Confirm the current open c7 issues appear here as `[c7#…]` mirrors with the `Source: c7` label + back-links.
4. Re-run → confirm no duplicates are created.