### PR TITLE
ci: add CODEOWNERS and route dependabot reviews via code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owner — requested as reviewer on every PR, including Dependabot's.
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+* @emaarco

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,11 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 19
-    assignees:
-      - "emaarco"
     labels:
       - "Type: dependencies"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-    assignees:
-      - "emaarco"
     labels:
       - "Type: dependencies"


### PR DESCRIPTION
## What
- Add `.github/CODEOWNERS` with `* @emaarco` as the default owner, so he is automatically requested as **reviewer** on every PR — including Dependabot's.
- Remove the now-redundant `assignees` keys from `.github/dependabot.yml` (review routing is handled by CODEOWNERS).

## Why
CODEOWNERS is the canonical way to get reviewers requested on all PRs. Dependabot honors it, so the per-ecosystem `assignees` workaround is no longer needed.

Note: `assignees` set the PR *assignee* field, not a reviewer — CODEOWNERS gives proper review requests instead.