### PR TITLE
chore(dependabot): group actions into one PR, group maven minor/patch with majors separate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 version: 2
 updates:
+  # maven: minor + patch grouped, every major lands as its own PR
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
@@ -7,9 +8,39 @@ updates:
     open-pull-requests-limit: 19
     labels:
       - "Type: dependencies"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    cooldown:
+      default-days: 5
+      semver-major-days: 14
+      semver-minor-days: 5
+      semver-patch-days: 3
+    groups:
+      maven-minor-patch:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+      maven-security:
+        applies-to: security-updates
+        patterns: ["*"]
+
+  # github-actions: everything grouped into a single PR
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     labels:
       - "Type: dependencies"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    cooldown:
+      default-days: 5
+    groups:
+      github-actions:
+        applies-to: version-updates
+        patterns: ["*"]
+      github-actions-security:
+        applies-to: security-updates
+        patterns: ["*"]


### PR DESCRIPTION
## What

Restructures `.github/dependabot.yml` into **balanced** grouping (fits this public Maven Central library):

- **github-actions** — all updates (incl. majors) grouped into a **single PR**.
- **maven** — `minor` + `patch` grouped; **each major lands as its own PR** for individual review.

## Also added

- `commit-message` prefix (`chore` + scope) and `cooldown` (majors mature 14d, minor 5d, patch 3d) as a supply-chain guard — security updates are never delayed.
- `*-security` groups per ecosystem so CVEs batch instead of opening one PR each.
- Kept existing `Type: dependencies` label, `weekly` cadence, and maven `open-pull-requests-limit: 19`.

## Notes

- YAML validated locally.
- GitHub validates the config at run time — check **Insights → Dependency graph → Dependabot** after merge.